### PR TITLE
few minor improvements

### DIFF
--- a/examples/ci-tests/src/main.rs
+++ b/examples/ci-tests/src/main.rs
@@ -7,6 +7,8 @@ fn display_empty_data() {
     println!("EmptyData Length = {}\n", data.as_slice().len());
     println!("EmptyData Debug:\n{:?}\n", data);
     println!("EmptyData Display:\n{}\n", data);
+    println!("EmptyData LowerHex:\n{:x}\n", data);
+    println!("EmptyData LowerHex (alternate):\n{:#x}\n", data);
 }
 
 fn display_test_data() {

--- a/tools/codegen/src/generator/languages/rust/entity/mod.rs
+++ b/tools/codegen/src/generator/languages/rust/entity/mod.rs
@@ -36,10 +36,19 @@ where
             #[derive(Clone)]
             pub struct #entity(molecule::bytes::Bytes);
 
-            impl ::std::fmt::Debug for #entity {
+            impl ::std::fmt::LowerHex for #entity {
                 fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
                     use molecule::faster_hex::hex_string;
-                    write!(f, "{}(0x{})", Self::NAME, hex_string(self.as_slice()).unwrap())
+                    if f.alternate() {
+                        write!(f, "0x")?;
+                    }
+                    write!(f, "{}", hex_string(self.as_slice()).unwrap())
+                }
+            }
+
+            impl ::std::fmt::Debug for #entity {
+                fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                    write!(f, "{}({:#x})", Self::NAME, self)
                 }
             }
 

--- a/tools/codegen/src/generator/languages/rust/getters.rs
+++ b/tools/codegen/src/generator/languages/rust/getters.rs
@@ -77,7 +77,7 @@ impl ImplGetters for ast::Union {
                 let inner = #getter_stmt;
                 match self.item_id() {
                     #( #match_stmts )*
-                    _ => unreachable!(),
+                    _ => panic!("{}: invalid data", Self::NAME),
                 }
             }
         )

--- a/tools/codegen/src/generator/languages/rust/reader/mod.rs
+++ b/tools/codegen/src/generator/languages/rust/reader/mod.rs
@@ -30,10 +30,19 @@ where
             #[derive(Clone, Copy)]
             pub struct #reader<'r>(&'r [u8]);
 
-            impl<'r> ::std::fmt::Debug for #reader<'r> {
+            impl<'r> ::std::fmt::LowerHex for #reader<'r> {
                 fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
                     use molecule::faster_hex::hex_string;
-                    write!(f, "{}(0x{})", Self::NAME, hex_string(self.as_slice()).unwrap())
+                    if f.alternate() {
+                        write!(f, "0x")?;
+                    }
+                    write!(f, "{}", hex_string(self.as_slice()).unwrap())
+                }
+            }
+
+            impl<'r> ::std::fmt::Debug for #reader<'r> {
+                fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                    write!(f, "{}({:#x})", Self::NAME, self)
                 }
             }
 


### PR DESCRIPTION
- [x] chore(codegen/rust): replace a `unreachable` by `panic`
- [x] chore(codegen/rust): replace `try_err` by returning error directly ([Reason](https://rust-lang.github.io/rust-clippy/master/index.html#try_err))
- [x] feat(codegen/rust): implement `std::fmt::LowerHex` trait for `Entity` and `Reader`