### PR TITLE
Support Rust no_std

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ci: ci-example ci-rust ci-c
 
-RUST_PROJS = examples/ci-tests bindings/rust tools/codegen tools/compiler
+RUST_PROJS = examples/ci-tests examples/nostd-tests bindings/rust tools/codegen tools/compiler
 C_PROJS = examples/ci-tests
 
 clean:

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -10,9 +10,14 @@ keywords = ["serialization"]
 categories = ["encoding", "data-structures"]
 license = "MIT"
 
+[features]
+default = ["std"]
+std = []
+
 [dependencies]
 bytes = "~0.4"
 faster-hex = "~0.4"
+failure = { version = "0.1", default-features = false, features = ["derive"] }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -12,12 +12,12 @@ license = "MIT"
 
 [features]
 default = ["std"]
-std = []
+std = ["faster-hex"]
 
 [dependencies]
-bytes = "~0.4"
-faster-hex = "~0.4"
+bytes = { version = "~0.5", default-features = false }
 failure = { version = "0.1", default-features = false, features = ["derive"] }
+faster-hex = { version = "~0.4", optional = true }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/bindings/rust/src/error.rs
+++ b/bindings/rust/src/error.rs
@@ -1,4 +1,4 @@
-use std::{error, fmt, result};
+use core::{fmt, result};
 
 use crate::Number;
 
@@ -6,17 +6,17 @@ use crate::Number;
 #[macro_export]
 macro_rules! verification_error {
     ($self:ident, $err:ident $(, $args:expr )*) => {
-        Err($crate::error::VerificationError::$err($self::NAME.to_owned() $(, $args )*))
+        Err($crate::error::VerificationError::$err($self::NAME $(, $args )*))
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Fail)]
 pub enum VerificationError {
-    TotalSizeNotMatch(String, usize, usize),
-    HeaderIsBroken(String, usize, usize),
-    UnknownItem(String, usize, Number),
-    OffsetsNotMatch(String),
-    FieldCountNotMatch(String, usize, usize),
+    TotalSizeNotMatch(&'static str, usize, usize),
+    HeaderIsBroken(&'static str, usize, usize),
+    UnknownItem(&'static str, usize, Number),
+    OffsetsNotMatch(&'static str),
+    FieldCountNotMatch(&'static str, usize, usize),
 }
 
 pub type VerificationResult<T> = result::Result<T, VerificationError>;
@@ -60,9 +60,7 @@ impl fmt::Display for VerificationError {
     }
 }
 
-impl error::Error for VerificationError {}
-
-#[derive(Debug)]
+#[derive(Debug, Fail)]
 pub enum Error {
     Verification(VerificationError),
 }
@@ -79,5 +77,3 @@ impl fmt::Display for Error {
         Ok(())
     }
 }
-
-impl error::Error for Error {}

--- a/bindings/rust/src/hex.rs
+++ b/bindings/rust/src/hex.rs
@@ -1,0 +1,16 @@
+#[cfg(feature = "std")]
+pub fn hex_string(input: &[u8]) -> String {
+    faster_hex::hex_string(input).unwrap()
+}
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+pub fn hex_string(input: &[u8]) -> alloc::string::String {
+    use core::fmt::Write;
+    let mut buf = alloc::string::String::new();
+    for b in input {
+        write!(buf, "{:02x}", b).expect("write hex byte error");
+    }
+    buf
+}

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -1,4 +1,9 @@
-use std::mem::size_of;
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[macro_use]
+extern crate failure;
+
+use core::mem::size_of;
 
 pub mod error;
 pub mod prelude;

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -6,11 +6,12 @@ extern crate failure;
 use core::mem::size_of;
 
 pub mod error;
+mod hex;
 pub mod prelude;
 mod primitive;
 
 pub use bytes;
-pub use faster_hex;
+pub use hex::hex_string;
 
 // Little Endian
 pub type Number = u32;

--- a/bindings/rust/src/prelude.rs
+++ b/bindings/rust/src/prelude.rs
@@ -1,6 +1,4 @@
 use core::{clone::Clone, default::Default, fmt};
-#[cfg(feature = "std")]
-use std::io;
 
 use bytes::Bytes;
 
@@ -39,8 +37,6 @@ pub trait Builder: Default {
     type Entity: Entity;
     const NAME: &'static str;
     fn expected_length(&self) -> usize;
-    #[cfg(feature = "std")]
-    fn write<W: io::Write>(&self, writer: &mut W) -> io::Result<()>;
     fn write_buf<B: bytes::BufMut>(&self, buf: &mut B);
     fn build(&self) -> Self::Entity;
 }

--- a/bindings/rust/src/prelude.rs
+++ b/bindings/rust/src/prelude.rs
@@ -1,4 +1,6 @@
-use std::{clone::Clone, default::Default, fmt, io};
+use core::{clone::Clone, default::Default, fmt};
+#[cfg(feature = "std")]
+use std::io;
 
 use bytes::Bytes;
 
@@ -37,6 +39,7 @@ pub trait Builder: Default {
     type Entity: Entity;
     const NAME: &'static str;
     fn expected_length(&self) -> usize;
+    #[cfg(feature = "std")]
     fn write<W: io::Write>(&self, writer: &mut W) -> io::Result<()>;
     fn build(&self) -> Self::Entity;
 }

--- a/bindings/rust/src/prelude.rs
+++ b/bindings/rust/src/prelude.rs
@@ -41,5 +41,6 @@ pub trait Builder: Default {
     fn expected_length(&self) -> usize;
     #[cfg(feature = "std")]
     fn write<W: io::Write>(&self, writer: &mut W) -> io::Result<()>;
+    fn write_buf<B: bytes::BufMut>(&self, buf: &mut B);
     fn build(&self) -> Self::Entity;
 }

--- a/bindings/rust/src/primitive.rs
+++ b/bindings/rust/src/primitive.rs
@@ -64,7 +64,7 @@ impl Byte {
 
     #[inline]
     pub fn as_bytes(self) -> Bytes {
-        self.as_slice().into()
+        self.as_slice().to_vec().into()
     }
 
     #[inline]

--- a/bindings/rust/src/primitive.rs
+++ b/bindings/rust/src/primitive.rs
@@ -1,4 +1,4 @@
-use std::{default::Default, fmt};
+use core::{default::Default, fmt};
 
 use crate::{bytes::Bytes, error::VerificationResult, verification_error};
 
@@ -80,7 +80,7 @@ impl Byte {
 
 // As Reader
 impl<'r> ByteReader<'r> {
-    pub const NAME: &'r str = "ByteReader";
+    pub const NAME: &'static str = "ByteReader";
 
     #[inline]
     pub fn to_entity(self) -> Byte {

--- a/examples/nostd-tests/.gitignore
+++ b/examples/nostd-tests/.gitignore
@@ -1,0 +1,9 @@
+target/
+Cargo.lock
+
+c/ci_tests_api.h
+c/ci_tests_gen.h
+
+/tmp
+/ci_test_simple
+/ci_test_build

--- a/examples/nostd-tests/Cargo.toml
+++ b/examples/nostd-tests/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "molecule-nostd-tests"
+version = "0.4.0"
+authors = ["Nervos Core Dev <dev@nervos.org>"]
+edition = "2018"
+
+[dependencies]
+molecule = { path = "../../bindings/rust", default-features = false }
+
+[build-dependencies]
+codegen = { package ="molecule-codegen", path = "../../tools/codegen" }
+
+[dev-dependencies]
+slices = "~0.1"

--- a/examples/nostd-tests/Makefile
+++ b/examples/nostd-tests/Makefile
@@ -1,0 +1,37 @@
+MOLC = ../../tools/compiler/target/release/moleculec
+
+SCHEMA = ci_tests
+SCHEMA_FILE = schemas/${SCHEMA}.mol
+
+TMPDIR = tmp
+TMP = ${TMPDIR} ${BINS} ${MOLC} \
+	  ${HEADER_API} ${HEADER_GEN}
+
+MOL_DEPS = refresh-comipler ${MOLC}
+
+clean:
+	@cargo clean
+	@rm -rf ${TMP}
+
+tmpdir:
+	@if [ ! -d "${TMPDIR}" ]; then mkdir -p "${TMPDIR}"; fi
+
+refresh-comipler:
+	@rm -f ${MOLC}
+
+debug:
+	@cargo build
+
+test: test-rust
+
+test-rust:
+	@cargo test --all
+
+${MOLC}:
+	@cd ../../tools/compiler; cargo build --release
+
+${HEADER_API}: ${SCHEMA_FILE} ${MOL_DEPS}
+	@"${MOLC}" --language c --schema-file $< > $@
+
+${HEADER_GEN}: ${SCHEMA_FILE}
+	@${SCRIPT_GEN_C} "${SCHEMA_FILE}" "${HEADER_GEN}"

--- a/examples/nostd-tests/build.rs
+++ b/examples/nostd-tests/build.rs
@@ -1,0 +1,15 @@
+use codegen::{Compiler, Language};
+
+fn compile_schema(schema: &str) {
+    let mut compiler = Compiler::new();
+    compiler
+        .language(Language::Rust)
+        .default_out_dir()
+        .file_path(schema)
+        .run();
+    println!("cargo:rerun-if-changed={}", schema);
+}
+
+fn main() {
+    compile_schema("schemas/ci_tests.mol");
+}

--- a/examples/nostd-tests/schemas/ci_tests.mol
+++ b/examples/nostd-tests/schemas/ci_tests.mol
@@ -1,0 +1,272 @@
+array Byte2 [byte; 2];
+array Byte3 [byte; 3];
+array Byte4 [byte; 4];
+array Byte5 [byte; 5];
+array Byte6 [byte; 6];
+array Byte7 [byte; 7];
+array Byte8 [byte; 8];
+array Byte9 [byte; 9];
+array Byte10 [byte; 10];
+array Byte11 [byte; 11];
+array Byte12 [byte; 12];
+array Byte13 [byte; 13];
+array Byte14 [byte; 14];
+array Byte15 [byte; 15];
+array Byte16 [byte; 16];
+
+array Word [byte; 2];
+array Word2 [Word; 2];
+array Word3 [Word; 3];
+array Word4 [Word; 4];
+array Word5 [Word; 5];
+array Word6 [Word; 6];
+array Word7 [Word; 7];
+array Word8 [Word; 8];
+
+array Byte3x3 [Byte3; 3];
+array Byte5x3 [Byte5; 3];
+array Byte7x3 [Byte7; 3];
+array Byte9x3 [Byte9; 3];
+
+struct StructA {
+    f1: byte,
+    f2: byte,
+    f3: Byte2,
+    f4: Byte2,
+}
+struct StructB {
+    f1: byte,
+    f2: byte,
+    f3: Byte2,
+    f4: Byte3,
+}
+struct StructC {
+    f1: byte,
+    f2: byte,
+    f3: Byte2,
+    f4: Byte4,
+}
+struct StructD {
+    f1: byte,
+    f2: byte,
+    f3: Byte2,
+    f4: Byte5,
+}
+struct StructE {
+    f1: byte,
+    f2: Byte2,
+    f3: byte,
+    f4: Byte2,
+}
+struct StructF {
+    f1: byte,
+    f2: Byte3,
+    f3: byte,
+}
+struct StructG {
+    f1: Byte3,
+    f2: byte,
+    f3: Byte2,
+    f4: Word2,
+}
+struct StructH {
+    f1: Byte3,
+    f2: byte,
+    f3: Byte2,
+    f4: Byte4,
+}
+struct StructI {
+    f1: Byte3,
+    f2: byte,
+}
+struct StructJ {
+    f1: Byte6,
+    f2: byte,
+}
+
+array StructIx3 [StructI; 3];
+
+struct StructO {
+    f1: StructIx3,
+    f2: byte,
+}
+struct StructP {
+    f1: StructJ,
+    f2: byte,
+}
+
+vector Bytes <byte>;
+vector Words <Word>;
+
+vector Byte3Vec <Byte3>;
+vector Byte7Vec <Byte7>;
+vector StructIVec <StructI>;
+vector StructJVec <StructJ>;
+vector StructPVec <StructP>;
+
+vector BytesVec <Bytes>;
+vector WordsVec <Words>;
+
+table Table0 {
+}
+
+table Table1 {
+    f1: byte,
+}
+
+table Table2 {
+    f1: byte,
+    f2: Word2,
+}
+
+table Table3 {
+    f1: byte,
+    f2: Word2,
+    f3: StructA,
+}
+
+table Table4 {
+    f1: byte,
+    f2: Word2,
+    f3: StructA,
+    f4: Bytes,
+}
+
+table Table5 {
+    f1: byte,
+    f2: Word2,
+    f3: StructA,
+    f4: Bytes,
+    f5: BytesVec,
+}
+
+table Table6 {
+    f1: byte,
+    f2: Word2,
+    f3: StructA,
+    f4: Bytes,
+    f5: BytesVec,
+    f6: Table5,
+}
+
+option ByteOpt (byte);
+option WordOpt (Word);
+option StructAOpt (StructA);
+option StructPOpt (StructP);
+option BytesOpt (Bytes);
+option WordsOpt (Words);
+option BytesVecOpt (BytesVec);
+option WordsVecOpt (WordsVec);
+option Table0Opt (Table0);
+option Table6Opt (Table6);
+option Table6OptOpt (Table6Opt);
+
+vector ByteOptVec <ByteOpt>;
+vector WordOptVec <WordOpt>;
+vector WordsOptVec <WordsOpt>;
+vector BytesOptVec <BytesOpt>;
+
+union UnionA {
+    byte,
+    Word,
+    StructA,
+    Bytes,
+    Words,
+    Table0,
+    Table6,
+    Table6Opt,
+}
+
+table TableA {
+    f0: Table0,
+    f1: Table1,
+    f2: Table2,
+    f3: Table3,
+    f4: Table4,
+    f5: Table5,
+    f6: Table6,
+    f7: UnionA,
+}
+
+/*
+ * ```sh
+ * grep -r "^\(option\|union\|array\|struct\|vector\|table\) " ci_tests.mol \
+ *     | awk '{ print $2 }' | cat -n | awk '{ print "f"$1": "$2"," }'
+ * ```
+ */
+table AllInOne {
+    f0: byte,
+    f1: Byte2,
+    f2: Byte3,
+    f3: Byte4,
+    f4: Byte5,
+    f5: Byte6,
+    f6: Byte7,
+    f7: Byte8,
+    f8: Byte9,
+    f9: Byte10,
+    f10: Byte11,
+    f11: Byte12,
+    f12: Byte13,
+    f13: Byte14,
+    f14: Byte15,
+    f15: Byte16,
+    f16: Word,
+    f17: Word2,
+    f18: Word3,
+    f19: Word4,
+    f20: Word5,
+    f21: Word6,
+    f22: Word7,
+    f23: Word8,
+    f24: Byte3x3,
+    f25: Byte5x3,
+    f26: Byte7x3,
+    f27: Byte9x3,
+    f28: StructA,
+    f29: StructB,
+    f30: StructC,
+    f31: StructD,
+    f32: StructE,
+    f33: StructF,
+    f34: StructG,
+    f35: StructH,
+    f36: StructI,
+    f37: StructJ,
+    f38: StructIx3,
+    f39: StructO,
+    f40: StructP,
+    f41: Bytes,
+    f42: Words,
+    f43: Byte3Vec,
+    f44: Byte7Vec,
+    f45: StructIVec,
+    f46: StructJVec,
+    f47: StructPVec,
+    f48: BytesVec,
+    f49: WordsVec,
+    f50: Table0,
+    f51: Table1,
+    f52: Table2,
+    f53: Table3,
+    f54: Table4,
+    f55: Table5,
+    f56: Table6,
+    f57: ByteOpt,
+    f58: WordOpt,
+    f59: StructAOpt,
+    f60: StructPOpt,
+    f61: BytesOpt,
+    f62: WordsOpt,
+    f63: BytesVecOpt,
+    f64: WordsVecOpt,
+    f65: Table0Opt,
+    f66: Table6Opt,
+    f67: Table6OptOpt,
+    f68: ByteOptVec,
+    f69: WordOptVec,
+    f70: WordsOptVec,
+    f71: BytesOptVec,
+    f72: UnionA,
+    f73: TableA,
+}

--- a/examples/nostd-tests/src/lib.rs
+++ b/examples/nostd-tests/src/lib.rs
@@ -1,0 +1,10 @@
+#![no_std]
+
+#[macro_use]
+extern crate alloc;
+
+pub mod types {
+    #![allow(clippy::all)]
+    pub use molecule::prelude::{Byte, ByteReader};
+    include!(concat!(env!("OUT_DIR"), "/", "ci_tests", ".rs"));
+}

--- a/tools/codegen/src/generator/languages/rust/builder/definition.rs
+++ b/tools/codegen/src/generator/languages/rust/builder/definition.rs
@@ -43,13 +43,13 @@ impl DefBuilder for ast::Array {
         quote!(
             pub struct #builder (pub(crate) [#inner; #item_count]);
 
-            impl ::std::fmt::Debug for #builder {
-                fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+            impl ::core::fmt::Debug for #builder {
+                fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                     write!(f, "{}({:?})", Self::NAME, &self.0[..])
                 }
             }
 
-            impl ::std::default::Default for #builder {
+            impl ::core::default::Default for #builder {
                 fn default() -> Self {
                     #builder([#(#inner_array::default(), )*])
                 }

--- a/tools/codegen/src/generator/languages/rust/builder/implementation.rs
+++ b/tools/codegen/src/generator/languages/rust/builder/implementation.rs
@@ -34,8 +34,12 @@ impl ImplBuilder for ast::Option_ {
             fn expected_length(&self) -> usize {
                 self.0.as_ref().map(|ref inner| inner.as_slice().len()).unwrap_or(0)
             }
+            #[cfg(feature = "std")]
             fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
                 self.0.as_ref().map(|ref inner| writer.write_all(inner.as_slice())).unwrap_or(Ok(()))
+            }
+            fn write_buf<B: molecule::bytes::BufMut>(&self, buf: &mut B) {
+                self.0.as_ref().map(|ref inner| buf.put_slice(inner.as_slice()));
             }
         )
     }
@@ -47,9 +51,14 @@ impl ImplBuilder for ast::Union {
             fn expected_length(&self) -> usize {
                 molecule::NUMBER_SIZE + self.0.as_slice().len()
             }
+            #[cfg(feature = "std")]
             fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
                 writer.write_all(&molecule::pack_number(self.0.item_id()))?;
                 writer.write_all(self.0.as_slice())
+            }
+            fn write_buf<B: molecule::bytes::BufMut>(&self, buf: &mut B) {
+                buf.put_slice(&molecule::pack_number(self.0.item_id()));
+                buf.put_slice(self.0.as_slice());
             }
         )
     }
@@ -65,13 +74,25 @@ impl ImplBuilder for ast::Array {
                 )*
             )
         };
+        let buf_inners = {
+            let idx = (0..self.item_count).map(usize_lit).collect::<Vec<_>>();
+            quote!(
+                #(
+                    buf.put_slice(self.0[#idx].as_slice());
+                )*
+            )
+        };
         quote!(
             fn expected_length(&self) -> usize {
                 Self::TOTAL_SIZE
             }
+            #[cfg(feature = "std")]
             fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
                 #write_inners
                 Ok(())
+            }
+            fn write_buf<B: molecule::bytes::BufMut>(&self, buf: &mut B) {
+                #( #buf_inners )*
             }
         )
     }
@@ -85,13 +106,23 @@ impl ImplBuilder for ast::Struct {
                 writer.write_all(self.#field_name.as_slice())?;
             )
         });
+        let buf_fields = self.inner.iter().map(|f| {
+            let field_name = field_name(&f.name);
+            quote!(
+                buf.put_slice(self.#field_name.as_slice());
+            )
+        });
         quote!(
             fn expected_length(&self) -> usize {
                 Self::TOTAL_SIZE
             }
+            #[cfg(feature = "std")]
             fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
                 #( #fields )*
                 Ok(())
+            }
+            fn write_buf<B: molecule::bytes::BufMut>(&self, buf: &mut B) {
+                #( #buf_fields )*
             }
         )
     }
@@ -102,14 +133,22 @@ impl ImplBuilder for ast::FixVec {
         let write_inners = quote!(for inner in &self.0[..] {
             writer.write_all(inner.as_slice())?;
         });
+        let buf_inners = quote!(for inner in &self.0[..] {
+            buf.put_slice(inner.as_slice());
+        });
         quote!(
             fn expected_length(&self) -> usize {
                 molecule::NUMBER_SIZE + Self::ITEM_SIZE * self.0.len()
             }
+            #[cfg(feature = "std")]
             fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
                 writer.write_all(&molecule::pack_number(self.0.len() as molecule::Number))?;
                 #write_inners
                 Ok(())
+            }
+            fn write_buf<B: molecule::bytes::BufMut>(&self, buf: &mut B) {
+                buf.put_slice(&molecule::pack_number(self.0.len() as molecule::Number));
+                #buf_inners
             }
         )
     }
@@ -122,6 +161,7 @@ impl ImplBuilder for ast::DynVec {
                 molecule::NUMBER_SIZE * (self.0.len() + 1)
                     + self.0.iter().map(|inner| inner.as_slice().len()).sum::<usize>()
             }
+            #[cfg(feature = "std")]
             fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
                 let item_count = self.0.len();
                 if item_count == 0 {
@@ -147,6 +187,30 @@ impl ImplBuilder for ast::DynVec {
                 }
                 Ok(())
             }
+            fn write_buf<B: molecule::bytes::BufMut>(&self, buf: &mut B) {
+                let item_count = self.0.len();
+                if item_count == 0 {
+                    buf.put_slice(&molecule::pack_number(molecule::NUMBER_SIZE as molecule::Number));
+                } else {
+                    let (total_size, offsets) = self.0.iter().fold(
+                        (
+                            molecule::NUMBER_SIZE * (item_count + 1),
+                            Vec::with_capacity(item_count),
+                        ),
+                        |(start, mut offsets), inner| {
+                            offsets.push(start);
+                            (start + inner.as_slice().len(), offsets)
+                        },
+                    );
+                    buf.put_slice(&molecule::pack_number(total_size as molecule::Number));
+                    for offset in offsets.into_iter() {
+                        buf.put_slice(&molecule::pack_number(offset as molecule::Number));
+                    }
+                    for inner in self.0.iter() {
+                        buf.put_slice(inner.as_slice());
+                    }
+                }
+            }
         )
     }
 }
@@ -158,9 +222,13 @@ impl ImplBuilder for ast::Table {
                 fn expected_length(&self) -> usize {
                     molecule::NUMBER_SIZE
                 }
+                #[cfg(feature = "std")]
                 fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
                     writer.write_all(&molecule::pack_number(molecule::NUMBER_SIZE as molecule::Number))?;
                     Ok(())
+                }
+                fn write_buf<B: molecule::bytes::BufMut>(&self, buf: &mut B) {
+                    buf.put_slice(&molecule::pack_number(molecule::NUMBER_SIZE as molecule::Number));
                 }
             )
         } else {
@@ -174,6 +242,7 @@ impl ImplBuilder for ast::Table {
                     molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1)
                         #(+ self.#field.as_slice().len())*
                 }
+                #[cfg(feature = "std")]
                 fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
                     let mut total_size = molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1);
                     let mut offsets = Vec::with_capacity(Self::FIELD_COUNT);
@@ -189,6 +258,21 @@ impl ImplBuilder for ast::Table {
                         writer.write_all(self.#field.as_slice())?;
                     )*
                     Ok(())
+                }
+                fn write_buf<B: molecule::bytes::BufMut>(&self, buf: &mut B) {
+                    let mut total_size = molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1);
+                    let mut offsets = Vec::with_capacity(Self::FIELD_COUNT);
+                    #(
+                        offsets.push(total_size);
+                        total_size += self.#field.as_slice().len();
+                    )*
+                    buf.put_slice(&molecule::pack_number(total_size as molecule::Number));
+                    for offset in offsets.into_iter() {
+                        buf.put_slice(&molecule::pack_number(offset as molecule::Number));
+                    }
+                    #(
+                        buf.put_slice(self.#field.as_slice());
+                    )*
                 }
             )
         }

--- a/tools/codegen/src/generator/languages/rust/builder/implementation.rs
+++ b/tools/codegen/src/generator/languages/rust/builder/implementation.rs
@@ -19,8 +19,7 @@ pub(in super::super) trait ImplBuilder: HasName {
                 #internal
                 fn build(&self) -> Self::Entity {
                     let mut inner = Vec::with_capacity(self.expected_length());
-                    self.write(&mut inner)
-                        .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
+                    self.write_buf(&mut inner);
                     #entity::new_unchecked(inner.into())
                 }
             }
@@ -33,10 +32,6 @@ impl ImplBuilder for ast::Option_ {
         quote!(
             fn expected_length(&self) -> usize {
                 self.0.as_ref().map(|ref inner| inner.as_slice().len()).unwrap_or(0)
-            }
-            #[cfg(feature = "std")]
-            fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
-                self.0.as_ref().map(|ref inner| writer.write_all(inner.as_slice())).unwrap_or(Ok(()))
             }
             fn write_buf<B: molecule::bytes::BufMut>(&self, buf: &mut B) {
                 self.0.as_ref().map(|ref inner| buf.put_slice(inner.as_slice()));
@@ -51,11 +46,6 @@ impl ImplBuilder for ast::Union {
             fn expected_length(&self) -> usize {
                 molecule::NUMBER_SIZE + self.0.as_slice().len()
             }
-            #[cfg(feature = "std")]
-            fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
-                writer.write_all(&molecule::pack_number(self.0.item_id()))?;
-                writer.write_all(self.0.as_slice())
-            }
             fn write_buf<B: molecule::bytes::BufMut>(&self, buf: &mut B) {
                 buf.put_slice(&molecule::pack_number(self.0.item_id()));
                 buf.put_slice(self.0.as_slice());
@@ -66,14 +56,6 @@ impl ImplBuilder for ast::Union {
 
 impl ImplBuilder for ast::Array {
     fn impl_builder_internal(&self) -> m4::TokenStream {
-        let write_inners = {
-            let idx = (0..self.item_count).map(usize_lit).collect::<Vec<_>>();
-            quote!(
-                #(
-                    writer.write_all(self.0[#idx].as_slice())?;
-                )*
-            )
-        };
         let buf_inners = {
             let idx = (0..self.item_count).map(usize_lit).collect::<Vec<_>>();
             quote!(
@@ -85,11 +67,6 @@ impl ImplBuilder for ast::Array {
         quote!(
             fn expected_length(&self) -> usize {
                 Self::TOTAL_SIZE
-            }
-            #[cfg(feature = "std")]
-            fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
-                #write_inners
-                Ok(())
             }
             fn write_buf<B: molecule::bytes::BufMut>(&self, buf: &mut B) {
                 #( #buf_inners )*
@@ -103,12 +80,6 @@ impl ImplBuilder for ast::Struct {
         let fields = self.inner.iter().map(|f| {
             let field_name = field_name(&f.name);
             quote!(
-                writer.write_all(self.#field_name.as_slice())?;
-            )
-        });
-        let buf_fields = self.inner.iter().map(|f| {
-            let field_name = field_name(&f.name);
-            quote!(
                 buf.put_slice(self.#field_name.as_slice());
             )
         });
@@ -116,13 +87,8 @@ impl ImplBuilder for ast::Struct {
             fn expected_length(&self) -> usize {
                 Self::TOTAL_SIZE
             }
-            #[cfg(feature = "std")]
-            fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
-                #( #fields )*
-                Ok(())
-            }
             fn write_buf<B: molecule::bytes::BufMut>(&self, buf: &mut B) {
-                #( #buf_fields )*
+                #( #fields )*
             }
         )
     }
@@ -130,21 +96,12 @@ impl ImplBuilder for ast::Struct {
 
 impl ImplBuilder for ast::FixVec {
     fn impl_builder_internal(&self) -> m4::TokenStream {
-        let write_inners = quote!(for inner in &self.0[..] {
-            writer.write_all(inner.as_slice())?;
-        });
         let buf_inners = quote!(for inner in &self.0[..] {
             buf.put_slice(inner.as_slice());
         });
         quote!(
             fn expected_length(&self) -> usize {
                 molecule::NUMBER_SIZE + Self::ITEM_SIZE * self.0.len()
-            }
-            #[cfg(feature = "std")]
-            fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
-                writer.write_all(&molecule::pack_number(self.0.len() as molecule::Number))?;
-                #write_inners
-                Ok(())
             }
             fn write_buf<B: molecule::bytes::BufMut>(&self, buf: &mut B) {
                 buf.put_slice(&molecule::pack_number(self.0.len() as molecule::Number));
@@ -160,32 +117,6 @@ impl ImplBuilder for ast::DynVec {
             fn expected_length(&self) -> usize {
                 molecule::NUMBER_SIZE * (self.0.len() + 1)
                     + self.0.iter().map(|inner| inner.as_slice().len()).sum::<usize>()
-            }
-            #[cfg(feature = "std")]
-            fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
-                let item_count = self.0.len();
-                if item_count == 0 {
-                    writer.write_all(&molecule::pack_number(molecule::NUMBER_SIZE as molecule::Number))?;
-                } else {
-                    let (total_size, offsets) = self.0.iter().fold(
-                        (
-                            molecule::NUMBER_SIZE * (item_count + 1),
-                            Vec::with_capacity(item_count),
-                        ),
-                        |(start, mut offsets), inner| {
-                            offsets.push(start);
-                            (start + inner.as_slice().len(), offsets)
-                        },
-                    );
-                    writer.write_all(&molecule::pack_number(total_size as molecule::Number))?;
-                    for offset in offsets.into_iter() {
-                        writer.write_all(&molecule::pack_number(offset as molecule::Number))?;
-                    }
-                    for inner in self.0.iter() {
-                        writer.write_all(inner.as_slice())?;
-                    }
-                }
-                Ok(())
             }
             fn write_buf<B: molecule::bytes::BufMut>(&self, buf: &mut B) {
                 let item_count = self.0.len();
@@ -222,11 +153,6 @@ impl ImplBuilder for ast::Table {
                 fn expected_length(&self) -> usize {
                     molecule::NUMBER_SIZE
                 }
-                #[cfg(feature = "std")]
-                fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
-                    writer.write_all(&molecule::pack_number(molecule::NUMBER_SIZE as molecule::Number))?;
-                    Ok(())
-                }
                 fn write_buf<B: molecule::bytes::BufMut>(&self, buf: &mut B) {
                     buf.put_slice(&molecule::pack_number(molecule::NUMBER_SIZE as molecule::Number));
                 }
@@ -241,23 +167,6 @@ impl ImplBuilder for ast::Table {
                 fn expected_length(&self) -> usize {
                     molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1)
                         #(+ self.#field.as_slice().len())*
-                }
-                #[cfg(feature = "std")]
-                fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
-                    let mut total_size = molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1);
-                    let mut offsets = Vec::with_capacity(Self::FIELD_COUNT);
-                    #(
-                        offsets.push(total_size);
-                        total_size += self.#field.as_slice().len();
-                    )*
-                    writer.write_all(&molecule::pack_number(total_size as molecule::Number))?;
-                    for offset in offsets.into_iter() {
-                        writer.write_all(&molecule::pack_number(offset as molecule::Number))?;
-                    }
-                    #(
-                        writer.write_all(self.#field.as_slice())?;
-                    )*
-                    Ok(())
                 }
                 fn write_buf<B: molecule::bytes::BufMut>(&self, buf: &mut B) {
                     let mut total_size = molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1);

--- a/tools/codegen/src/generator/languages/rust/builder/setters.rs
+++ b/tools/codegen/src/generator/languages/rust/builder/setters.rs
@@ -26,7 +26,7 @@ impl ImplSetters for ast::Union {
         quote!(
             pub fn set<I>(mut self, v: I) -> Self
             where
-                I: ::std::convert::Into<#entity_union>
+                I: ::core::convert::Into<#entity_union>
             {
                 self.0 = v.into();
                 self
@@ -118,7 +118,7 @@ fn impl_setters_for_vector(inner_name: &str) -> m4::TokenStream {
             self.0.push(v);
             self
         }
-        pub fn extend<T: ::std::iter::IntoIterator<Item=#inner>>(mut self, iter: T) -> Self {
+        pub fn extend<T: ::core::iter::IntoIterator<Item=#inner>>(mut self, iter: T) -> Self {
             for elem in iter {
                 self.0.push(elem);
             }

--- a/tools/codegen/src/generator/languages/rust/display.rs
+++ b/tools/codegen/src/generator/languages/rust/display.rs
@@ -32,8 +32,8 @@ impl ImplDisplay for ast::Array {
     fn impl_display(&self) -> m4::TokenStream {
         if self.typ.is_atom() {
             quote!(
-                use molecule::faster_hex::hex_string;
-                let raw_data = hex_string(&self.raw_data()).unwrap();
+                use molecule::hex_string;
+                let raw_data = hex_string(&self.raw_data());
                 write!(f, "{}(0x{})", Self::NAME, raw_data)
             )
         } else {
@@ -77,8 +77,8 @@ impl ImplDisplay for ast::FixVec {
     fn impl_display(&self) -> m4::TokenStream {
         if self.typ.is_atom() {
             quote!(
-                use molecule::faster_hex::hex_string;
-                let raw_data = hex_string(&self.raw_data()).unwrap();
+                use molecule::hex_string;
+                let raw_data = hex_string(&self.raw_data());
                 write!(f, "{}(0x{})", Self::NAME, raw_data)
             )
         } else {

--- a/tools/codegen/src/generator/languages/rust/entity/implementation.rs
+++ b/tools/codegen/src/generator/languages/rust/entity/implementation.rs
@@ -33,7 +33,7 @@ pub(in super::super) trait ImplEntity: HasName {
                     #reader::from_compatible_slice(slice).map(|reader| reader.to_entity())
                 }
                 fn new_builder() -> Self::Builder {
-                    ::std::default::Default::default()
+                    ::core::default::Default::default()
                 }
                 #internal
             }

--- a/tools/codegen/src/generator/languages/rust/entity/mod.rs
+++ b/tools/codegen/src/generator/languages/rust/entity/mod.rs
@@ -36,8 +36,8 @@ where
             #[derive(Clone)]
             pub struct #entity(molecule::bytes::Bytes);
 
-            impl ::std::fmt::LowerHex for #entity {
-                fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+            impl ::core::fmt::LowerHex for #entity {
+                fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                     use molecule::faster_hex::hex_string;
                     if f.alternate() {
                         write!(f, "0x")?;
@@ -46,19 +46,19 @@ where
                 }
             }
 
-            impl ::std::fmt::Debug for #entity {
-                fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+            impl ::core::fmt::Debug for #entity {
+                fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                     write!(f, "{}({:#x})", Self::NAME, self)
                 }
             }
 
-            impl ::std::fmt::Display for #entity {
-                fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+            impl ::core::fmt::Display for #entity {
+                fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                     #display_stmts
                 }
             }
 
-            impl ::std::default::Default for #entity {
+            impl ::core::default::Default for #entity {
                 fn default() -> Self {
                     let v: Vec<u8> = vec![#( #default_content, )*];
                     #entity::new_unchecked(v.into())

--- a/tools/codegen/src/generator/languages/rust/entity/mod.rs
+++ b/tools/codegen/src/generator/languages/rust/entity/mod.rs
@@ -38,11 +38,11 @@ where
 
             impl ::core::fmt::LowerHex for #entity {
                 fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-                    use molecule::faster_hex::hex_string;
+                    use molecule::hex_string;
                     if f.alternate() {
                         write!(f, "0x")?;
                     }
-                    write!(f, "{}", hex_string(self.as_slice()).unwrap())
+                    write!(f, "{}", hex_string(self.as_slice()))
                 }
             }
 

--- a/tools/codegen/src/generator/languages/rust/enumerator.rs
+++ b/tools/codegen/src/generator/languages/rust/enumerator.rs
@@ -74,7 +74,7 @@ impl GenEnumerator for ast::Union {
         let entity_default = {
             let inner = &self.inner[0];
             let item_name = union_item_name(inner.typ.name());
-            quote!(#item_name(::std::default::Default::default()))
+            quote!(#item_name(::core::default::Default::default()))
         };
         let code_union_definitions_and_impl_traits = quote!(
             #[derive(Debug, Clone)]
@@ -86,14 +86,14 @@ impl GenEnumerator for ast::Union {
                 #( #union_items(#reader_inners<'r>), )*
             }
 
-            impl ::std::default::Default for #entity_union {
+            impl ::core::default::Default for #entity_union {
                 fn default() -> Self {
                     #entity_union::#entity_default
                 }
             }
 
-            impl ::std::fmt::Display for #entity_union {
-                fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+            impl ::core::fmt::Display for #entity_union {
+                fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                     match self {
                         #(
                             #entity_union_item_paths(ref item) => {
@@ -103,8 +103,8 @@ impl GenEnumerator for ast::Union {
                     }
                 }
             }
-            impl<'r> ::std::fmt::Display for #reader_union<'r> {
-                fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+            impl<'r> ::core::fmt::Display for #reader_union<'r> {
+                fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                     match self {
                         #(
                             #reader_union_item_paths(ref item) => {
@@ -116,14 +116,14 @@ impl GenEnumerator for ast::Union {
             }
 
             impl #entity_union {
-                pub(crate) fn display_inner(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                pub(crate) fn display_inner(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                     match self {
                         #( #entity_union_item_paths(ref item) => write!(f, "{}", item), )*
                     }
                 }
             }
             impl<'r> #reader_union<'r> {
-                pub(crate) fn display_inner(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                pub(crate) fn display_inner(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                     match self {
                         #( #reader_union_item_paths(ref item) => write!(f, "{}", item), )*
                     }
@@ -135,7 +135,7 @@ impl GenEnumerator for ast::Union {
             .zip(entity_inners.iter())
             .map(|(item_name, entity_name)| {
                 quote!(
-                    impl ::std::convert::From<#entity_name> for #entity_union {
+                    impl ::core::convert::From<#entity_name> for #entity_union {
                         fn from(item: #entity_name) -> Self {
                             #entity_union::#item_name(item)
                         }
@@ -148,7 +148,7 @@ impl GenEnumerator for ast::Union {
             .zip(reader_inners.iter())
             .map(|(item_name, reader_name)| {
                 quote!(
-                    impl<'r> ::std::convert::From<#reader_name<'r>> for #reader_union<'r> {
+                    impl<'r> ::core::convert::From<#reader_name<'r>> for #reader_union<'r> {
                         fn from(item: #reader_name<'r>) -> Self {
                             #reader_union::#item_name(item)
                         }

--- a/tools/codegen/src/generator/languages/rust/getters.rs
+++ b/tools/codegen/src/generator/languages/rust/getters.rs
@@ -55,7 +55,7 @@ impl ImplGetters for ast::Union {
         let (getter_ret, getter_stmt) = if is_entity {
             let union = entity_union_name(self.name());
             let getter_ret = quote!(#union);
-            let getter_stmt = quote!(self.0.slice_from(molecule::NUMBER_SIZE));
+            let getter_stmt = quote!(self.0.slice(molecule::NUMBER_SIZE..));
             (getter_ret, getter_stmt)
         } else {
             let union = reader_union_name(self.name());
@@ -105,7 +105,7 @@ impl ImplGetters for ast::Array {
                 let start = usize_lit(self.item_size * i);
                 let end = usize_lit(self.item_size * (i + 1));
                 let getter_stmt = if is_entity {
-                    quote!(self.0.slice(#start, #end))
+                    quote!(self.0.slice(#start..#end))
                 } else {
                     quote!(&self.as_slice()[#start..#end])
                 };
@@ -150,7 +150,7 @@ impl ImplGetters for ast::Struct {
                 offset += s;
                 let end = usize_lit(offset);
                 let getter_stmt = if is_entity {
-                    quote!(self.0.slice(#start, #end))
+                    quote!(self.0.slice(#start..#end))
                 } else {
                     quote!(&self.as_slice()[#start..#end])
                 };
@@ -174,9 +174,9 @@ impl ImplGetters for ast::FixVec {
         let (inner, getter_ret, getter_stmt, getter_ret_atom, getter_stmt_atom) = if is_entity {
             let inner = entity_name(self.typ.name());
             let getter_ret = quote!(#inner);
-            let getter_stmt = quote!(self.0.slice(start, end));
+            let getter_stmt = quote!(self.0.slice(start..end));
             let getter_ret_atom = quote!(molecule::bytes::Bytes);
-            let getter_stmt_atom = quote!(self.0.slice_from(molecule::NUMBER_SIZE));
+            let getter_stmt_atom = quote!(self.0.slice(molecule::NUMBER_SIZE..));
             (
                 inner,
                 getter_ret,
@@ -230,8 +230,8 @@ impl ImplGetters for ast::DynVec {
         let (inner, getter_ret, getter_stmt_last, getter_stmt) = if is_entity {
             let inner = entity_name(self.typ.name());
             let getter_ret = quote!(#inner);
-            let getter_stmt_last = quote!(self.0.slice_from(start));
-            let getter_stmt = quote!(self.0.slice(start, end));
+            let getter_stmt_last = quote!(self.0.slice(start..));
+            let getter_stmt = quote!(self.0.slice(start..end));
             (inner, getter_ret, getter_stmt_last, getter_stmt)
         } else {
             let inner = reader_name(self.typ.name());
@@ -265,8 +265,8 @@ impl ImplGetters for ast::DynVec {
 impl ImplGetters for ast::Table {
     fn impl_getters_internal(&self, is_entity: bool) -> m4::TokenStream {
         let (getter_stmt_last, getter_stmt) = if is_entity {
-            let getter_stmt_last = quote!(self.0.slice_from(start));
-            let getter_stmt = quote!(self.0.slice(start, end));
+            let getter_stmt_last = quote!(self.0.slice(start..));
+            let getter_stmt = quote!(self.0.slice(start..end));
             (getter_stmt_last, getter_stmt)
         } else {
             let getter_stmt_last = quote!(&self.as_slice()[start..]);

--- a/tools/codegen/src/generator/languages/rust/iterator.rs
+++ b/tools/codegen/src/generator/languages/rust/iterator.rs
@@ -29,7 +29,7 @@ fn gen_iterator_for_vector(self_name: &str, inner_name: &str, is_atom: bool) -> 
     let reader_inner = reader_name(inner_name);
     let common_part = quote!(
         pub struct #entity_iterator (#entity, usize, usize);
-        impl ::std::iter::Iterator for #entity_iterator {
+        impl ::core::iter::Iterator for #entity_iterator {
             type Item = #entity_inner;
             fn next(&mut self) -> Option<Self::Item> {
                 if self.1 >= self.2 {
@@ -41,12 +41,12 @@ fn gen_iterator_for_vector(self_name: &str, inner_name: &str, is_atom: bool) -> 
                 }
             }
         }
-        impl ::std::iter::ExactSizeIterator for #entity_iterator {
+        impl ::core::iter::ExactSizeIterator for #entity_iterator {
             fn len(&self) -> usize {
                 self.2 - self.1
             }
         }
-        impl ::std::iter::IntoIterator for #entity {
+        impl ::core::iter::IntoIterator for #entity {
             type Item = #entity_inner;
             type IntoIter = #entity_iterator;
             fn into_iter(self) -> Self::IntoIter {
@@ -67,7 +67,7 @@ fn gen_iterator_for_vector(self_name: &str, inner_name: &str, is_atom: bool) -> 
                 }
             }
             pub struct #reader_iterator<'t, 'r> (&'t #reader<'r>, usize, usize);
-            impl<'t: 'r, 'r> ::std::iter::Iterator for #reader_iterator<'t, 'r> {
+            impl<'t: 'r, 'r> ::core::iter::Iterator for #reader_iterator<'t, 'r> {
                 type Item = #reader_inner<'t>;
                 fn next(&mut self) -> Option<Self::Item> {
                     if self.1 >= self.2 {
@@ -79,7 +79,7 @@ fn gen_iterator_for_vector(self_name: &str, inner_name: &str, is_atom: bool) -> 
                     }
                 }
             }
-            impl<'t: 'r, 'r> ::std::iter::ExactSizeIterator for #reader_iterator<'t, 'r> {
+            impl<'t: 'r, 'r> ::core::iter::ExactSizeIterator for #reader_iterator<'t, 'r> {
                 fn len(&self) -> usize {
                     self.2 - self.1
                 }

--- a/tools/codegen/src/generator/languages/rust/mod.rs
+++ b/tools/codegen/src/generator/languages/rust/mod.rs
@@ -42,6 +42,8 @@ impl super::LanguageGenerator for Generator {
         writeln!(writer)?;
         let code = quote!(
             use molecule::prelude::*;
+            extern crate alloc;
+            use alloc::vec::Vec;
         );
         write!(writer, "{}", code)?;
         let major_imports = ast.major_imports();

--- a/tools/codegen/src/generator/languages/rust/reader/implementation.rs
+++ b/tools/codegen/src/generator/languages/rust/reader/implementation.rs
@@ -17,7 +17,7 @@ pub(in super::super) trait ImplReader: HasName {
                 type Entity = #entity;
                 const NAME: &'static str = #reader_string;
                 fn to_entity(&self) -> Self::Entity {
-                    Self::Entity::new_unchecked(self.as_slice().into())
+                    Self::Entity::new_unchecked(self.as_slice().to_vec().into())
                 }
                 fn new_unchecked(slice: &'r [u8]) -> Self {
                     #reader(slice)

--- a/tools/codegen/src/generator/languages/rust/reader/mod.rs
+++ b/tools/codegen/src/generator/languages/rust/reader/mod.rs
@@ -30,8 +30,8 @@ where
             #[derive(Clone, Copy)]
             pub struct #reader<'r>(&'r [u8]);
 
-            impl<'r> ::std::fmt::LowerHex for #reader<'r> {
-                fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+            impl<'r> ::core::fmt::LowerHex for #reader<'r> {
+                fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                     use molecule::faster_hex::hex_string;
                     if f.alternate() {
                         write!(f, "0x")?;
@@ -40,14 +40,14 @@ where
                 }
             }
 
-            impl<'r> ::std::fmt::Debug for #reader<'r> {
-                fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+            impl<'r> ::core::fmt::Debug for #reader<'r> {
+                fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                     write!(f, "{}({:#x})", Self::NAME, self)
                 }
             }
 
-            impl<'r> ::std::fmt::Display for #reader<'r> {
-                fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+            impl<'r> ::core::fmt::Display for #reader<'r> {
+                fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                     #display_stmts
                 }
             }

--- a/tools/codegen/src/generator/languages/rust/reader/mod.rs
+++ b/tools/codegen/src/generator/languages/rust/reader/mod.rs
@@ -32,11 +32,11 @@ where
 
             impl<'r> ::core::fmt::LowerHex for #reader<'r> {
                 fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-                    use molecule::faster_hex::hex_string;
+                    use molecule::hex_string;
                     if f.alternate() {
                         write!(f, "0x")?;
                     }
-                    write!(f, "{}", hex_string(self.as_slice()).unwrap())
+                    write!(f, "{}", hex_string(self.as_slice()))
                 }
             }
 

--- a/tools/compiler/Cargo.lock
+++ b/tools/compiler/Cargo.lock
@@ -89,6 +89,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "failure"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +149,7 @@ name = "molecule"
 version = "0.4.0"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "faster-hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -279,6 +299,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -365,6 +396,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum case 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fd6c0e7b807d60291f42f33f58480c0bfafe28ed08286446f45e463728cf9c1c"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+"checksum failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
+"checksum failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum faster-hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ec0ddfd1edbd5feb84f73d3068f7e5edba48b438caee3fb8e9ccb3e58cc70c5a"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
@@ -386,6 +419,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum sha-1 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "23962131a91661d643c98940b20fcaffe62d776a823247be80a48fcb8b6fce68"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
+"checksum synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
 "checksum ucd-trie 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8f00ed7be0c1ff1e24f46c3d2af4859f7e863672ba3a6e92e7cff702bf9f06c2"

--- a/tools/compiler/Cargo.lock
+++ b/tools/compiler/Cargo.lock
@@ -53,12 +53,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bytes"
-version = "0.4.12"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "case"
@@ -126,15 +122,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iovec"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,7 +135,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "molecule"
 version = "0.4.0"
 dependencies = [
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "faster-hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -349,11 +336,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "winapi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -392,7 +374,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum block-padding 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6d4dc3af3ee2e12f3e5d224e5e1e3d73668abbeb69e566d361f7d5563a4fdf09"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
-"checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
+"checksum bytes 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1c85319f157e4e26c703678e68e26ab71a46c0199286fa670b21cc9fec13d895"
 "checksum case 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fd6c0e7b807d60291f42f33f58480c0bfafe28ed08286446f45e463728cf9c1c"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
@@ -401,7 +383,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum faster-hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ec0ddfd1edbd5feb84f73d3068f7e5edba48b438caee3fb8e9ccb3e58cc70c5a"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
-"checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
 "checksum maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
@@ -427,7 +408,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
-"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9"


### PR DESCRIPTION
* `bindings/rust` supports `std` feature which default enabled.
* Replace all `std` prefix with `core` in `bindings/rust` and Rust generated code.
* Use `falure::Error` instead `std::Error`, so we can use Error in no_std.
* Upgrade `bytes` to 0.5 which support `no_std` environment.
* Change `ImplBuilder ` interface to remove the dependent of `std::Write`.
* Add a `no_std` compile tests `examples/nostd-tests`

The result is both `bindings/rust` and Rust generated code can be used in both `std` or `no_std` environments.