### PR TITLE
feat: rust support `#![no_std]`

### DIFF
--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -11,8 +11,13 @@ categories = ["encoding", "data-structures"]
 license = "MIT"
 
 [dependencies]
-bytes = "~0.4"
-faster-hex = "~0.4"
+cfg-if = "~0.1"
+bytes = { version = "~0.4", optional = true }
+faster-hex = { version = "~0.4", optional = true }
+
+[features]
+default = ["std"]
+std = ["bytes", "faster-hex"]
 
 [badges]
 maintenance = { status = "experimental" }

--- a/bindings/rust/src/bytes.rs
+++ b/bindings/rust/src/bytes.rs
@@ -1,0 +1,45 @@
+use alloc::{borrow::ToOwned, vec::Vec};
+use core::{convert::From, ops::Deref};
+
+#[derive(Debug, Default, Clone)]
+pub struct Bytes(Vec<u8>);
+
+impl From<Vec<u8>> for Bytes {
+    fn from(value: Vec<u8>) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&[u8]> for Bytes {
+    fn from(value: &[u8]) -> Self {
+        Self(value.to_owned())
+    }
+}
+
+impl From<Bytes> for Vec<u8> {
+    fn from(value: Bytes) -> Self {
+        value.0
+    }
+}
+
+impl Deref for Bytes {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Bytes {
+    pub fn slice(&self, start: usize, end: usize) -> Self {
+        Self::from(&self.0[start..end])
+    }
+
+    pub fn slice_from(&self, start: usize) -> Self {
+        self.slice(start, self.len())
+    }
+
+    pub fn slice_to(&self, end: usize) -> Self {
+        self.slice(0, end)
+    }
+}

--- a/bindings/rust/src/error.rs
+++ b/bindings/rust/src/error.rs
@@ -1,4 +1,5 @@
-use std::{error, fmt, result};
+use alloc::string::String;
+use core::{fmt, result};
 
 use crate::Number;
 
@@ -60,8 +61,6 @@ impl fmt::Display for VerificationError {
     }
 }
 
-impl error::Error for VerificationError {}
-
 #[derive(Debug)]
 pub enum Error {
     Verification(VerificationError),
@@ -80,4 +79,9 @@ impl fmt::Display for Error {
     }
 }
 
-impl error::Error for Error {}
+cfg_if::cfg_if! {
+    if #[cfg(feature = "std")] {
+        impl ::std::error::Error for VerificationError {}
+        impl ::std::error::Error for Error {}
+    }
+}

--- a/bindings/rust/src/io.rs
+++ b/bindings/rust/src/io.rs
@@ -1,0 +1,16 @@
+use alloc::vec::Vec;
+use core::{convert, result};
+
+pub type Error = convert::Infallible;
+pub type Result<T> = result::Result<T, Error>;
+
+pub trait Write {
+    fn write_all(&mut self, buf: &[u8]) -> Result<()>;
+}
+
+impl Write for Vec<u8> {
+    fn write_all(&mut self, buf: &[u8]) -> Result<()> {
+        self.extend_from_slice(buf);
+        Ok(())
+    }
+}

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -1,11 +1,27 @@
-use std::mem::size_of;
+#![no_std]
+
+extern crate alloc;
+
+use alloc::string::String;
+use core::mem::size_of;
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "std")] {
+        extern crate std;
+
+        pub use bytes;
+        pub mod io {
+            pub use std::io::{Error, Result, Write};
+        }
+    } else {
+        pub mod bytes;
+        pub mod io;
+    }
+}
 
 pub mod error;
 pub mod prelude;
 mod primitive;
-
-pub use bytes;
-pub use faster_hex;
 
 // Little Endian
 pub type Number = u32;
@@ -29,5 +45,20 @@ pub fn unpack_number_vec(slice: &[u8]) -> &[[u8; 4]] {
     #[allow(clippy::cast_ptr_alignment)]
     unsafe {
         &*(slice as *const [u8] as *const [[u8; 4]])
+    }
+}
+
+pub fn hex_string(input: &[u8]) -> String {
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "std")] {
+            faster_hex::hex_string(input).unwrap()
+        } else {
+            use core::fmt::Write;
+            let mut buf = String::new();
+            for b in input {
+                let _ = write!(buf, "{:02x}", b);
+            }
+            buf
+        }
     }
 }

--- a/bindings/rust/src/prelude.rs
+++ b/bindings/rust/src/prelude.rs
@@ -1,8 +1,7 @@
-use std::{clone::Clone, default::Default, fmt, io};
+pub use alloc::{borrow::ToOwned, vec, vec::Vec};
+use core::{clone::Clone, default::Default, fmt};
 
-use bytes::Bytes;
-
-use crate::error::VerificationResult;
+use crate::{bytes::Bytes, error::VerificationResult, io};
 
 pub use crate::primitive::{Byte, ByteReader};
 

--- a/bindings/rust/src/primitive.rs
+++ b/bindings/rust/src/primitive.rs
@@ -1,4 +1,5 @@
-use std::{default::Default, fmt};
+use alloc::borrow::ToOwned;
+use core::{default::Default, fmt};
 
 use crate::{bytes::Bytes, error::VerificationResult, verification_error};
 

--- a/examples/ci-tests/Cargo.toml
+++ b/examples/ci-tests/Cargo.toml
@@ -5,10 +5,14 @@ authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 
 [dependencies]
-molecule = { path = "../../bindings/rust" }
+molecule = { path = "../../bindings/rust", default-features = false }
 
 [build-dependencies]
 codegen = { package ="molecule-codegen", path = "../../tools/codegen" }
 
 [dev-dependencies]
 slices = "~0.1"
+
+[features]
+default = ["std"]
+std = ["molecule/std"]

--- a/examples/ci-tests/Makefile
+++ b/examples/ci-tests/Makefile
@@ -34,18 +34,23 @@ refresh-comipler:
 debug:
 	@cargo build
 
-test: test-rust test-c test-mixed
+test: test-rust test-rust-no-std test-c test-mixed
 
 test-rust:
 	@cargo test --all
+
+test-rust-no-std:
+	@cargo test --all --no-default-features
 
 test-c: ci_test_build
 	@./ci_test_build
 
 test-mixed: tmpdir ci_test_simple
 	@set -eu; \
-	cargo run        | grep "^AllInOneTestData :  " > "${TMPDIR}/testdata-rust"; \
-	./ci_test_simple | grep "^AllInOneTestData :  " > "${TMPDIR}/testdata-c"; \
+	cargo run                       | grep "^AllInOneTestData :  " > "${TMPDIR}/testdata-rust"; \
+	cargo run --no-default-features | grep "^AllInOneTestData :  " > "${TMPDIR}/testdata-rust-no-std"; \
+	./ci_test_simple                | grep "^AllInOneTestData :  " > "${TMPDIR}/testdata-c"; \
+	diff "${TMPDIR}/testdata-rust" "${TMPDIR}/testdata-rust-no-std"; \
 	diff "${TMPDIR}/testdata-rust" "${TMPDIR}/testdata-c"; \
 	echo "Passed: Test Mixed."
 

--- a/examples/ci-tests/src/lib.rs
+++ b/examples/ci-tests/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 pub mod types {
     #![allow(clippy::all)]
     pub use molecule::prelude::{Byte, ByteReader};

--- a/tools/codegen/Cargo.toml
+++ b/tools/codegen/Cargo.toml
@@ -16,7 +16,7 @@ categories = [
 license = "MIT"
 
 [dependencies]
-molecule = { version = "=0.4.0", path = "../../bindings/rust" }
+molecule = { version = "=0.4.0", path = "../../bindings/rust", default-features = false }
 pest = "~2.1"
 pest_derive = "~2.1"
 quote = "~0.6"

--- a/tools/codegen/src/generator/languages/rust/builder/definition.rs
+++ b/tools/codegen/src/generator/languages/rust/builder/definition.rs
@@ -43,13 +43,13 @@ impl DefBuilder for ast::Array {
         quote!(
             pub struct #builder (pub(crate) [#inner; #item_count]);
 
-            impl ::std::fmt::Debug for #builder {
-                fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+            impl ::core::fmt::Debug for #builder {
+                fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                     write!(f, "{}({:?})", Self::NAME, &self.0[..])
                 }
             }
 
-            impl ::std::default::Default for #builder {
+            impl ::core::default::Default for #builder {
                 fn default() -> Self {
                     #builder([#(#inner_array::default(), )*])
                 }

--- a/tools/codegen/src/generator/languages/rust/builder/implementation.rs
+++ b/tools/codegen/src/generator/languages/rust/builder/implementation.rs
@@ -34,7 +34,7 @@ impl ImplBuilder for ast::Option_ {
             fn expected_length(&self) -> usize {
                 self.0.as_ref().map(|ref inner| inner.as_slice().len()).unwrap_or(0)
             }
-            fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
+            fn write<W: ::molecule::io::Write>(&self, writer: &mut W) -> ::molecule::io::Result<()> {
                 self.0.as_ref().map(|ref inner| writer.write_all(inner.as_slice())).unwrap_or(Ok(()))
             }
         )
@@ -47,7 +47,7 @@ impl ImplBuilder for ast::Union {
             fn expected_length(&self) -> usize {
                 molecule::NUMBER_SIZE + self.0.as_slice().len()
             }
-            fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
+            fn write<W: ::molecule::io::Write>(&self, writer: &mut W) -> ::molecule::io::Result<()> {
                 writer.write_all(&molecule::pack_number(self.0.item_id()))?;
                 writer.write_all(self.0.as_slice())
             }
@@ -69,7 +69,7 @@ impl ImplBuilder for ast::Array {
             fn expected_length(&self) -> usize {
                 Self::TOTAL_SIZE
             }
-            fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
+            fn write<W: ::molecule::io::Write>(&self, writer: &mut W) -> ::molecule::io::Result<()> {
                 #write_inners
                 Ok(())
             }
@@ -89,7 +89,7 @@ impl ImplBuilder for ast::Struct {
             fn expected_length(&self) -> usize {
                 Self::TOTAL_SIZE
             }
-            fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
+            fn write<W: ::molecule::io::Write>(&self, writer: &mut W) -> ::molecule::io::Result<()> {
                 #( #fields )*
                 Ok(())
             }
@@ -106,7 +106,7 @@ impl ImplBuilder for ast::FixVec {
             fn expected_length(&self) -> usize {
                 molecule::NUMBER_SIZE + Self::ITEM_SIZE * self.0.len()
             }
-            fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
+            fn write<W: ::molecule::io::Write>(&self, writer: &mut W) -> ::molecule::io::Result<()> {
                 writer.write_all(&molecule::pack_number(self.0.len() as molecule::Number))?;
                 #write_inners
                 Ok(())
@@ -122,7 +122,7 @@ impl ImplBuilder for ast::DynVec {
                 molecule::NUMBER_SIZE * (self.0.len() + 1)
                     + self.0.iter().map(|inner| inner.as_slice().len()).sum::<usize>()
             }
-            fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
+            fn write<W: ::molecule::io::Write>(&self, writer: &mut W) -> ::molecule::io::Result<()> {
                 let item_count = self.0.len();
                 if item_count == 0 {
                     writer.write_all(&molecule::pack_number(molecule::NUMBER_SIZE as molecule::Number))?;
@@ -158,7 +158,7 @@ impl ImplBuilder for ast::Table {
                 fn expected_length(&self) -> usize {
                     molecule::NUMBER_SIZE
                 }
-                fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
+                fn write<W: ::molecule::io::Write>(&self, writer: &mut W) -> ::molecule::io::Result<()> {
                     writer.write_all(&molecule::pack_number(molecule::NUMBER_SIZE as molecule::Number))?;
                     Ok(())
                 }
@@ -174,7 +174,7 @@ impl ImplBuilder for ast::Table {
                     molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1)
                         #(+ self.#field.as_slice().len())*
                 }
-                fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
+                fn write<W: ::molecule::io::Write>(&self, writer: &mut W) -> ::molecule::io::Result<()> {
                     let mut total_size = molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1);
                     let mut offsets = Vec::with_capacity(Self::FIELD_COUNT);
                     #(

--- a/tools/codegen/src/generator/languages/rust/builder/setters.rs
+++ b/tools/codegen/src/generator/languages/rust/builder/setters.rs
@@ -26,7 +26,7 @@ impl ImplSetters for ast::Union {
         quote!(
             pub fn set<I>(mut self, v: I) -> Self
             where
-                I: ::std::convert::Into<#entity_union>
+                I: ::core::convert::Into<#entity_union>
             {
                 self.0 = v.into();
                 self
@@ -118,7 +118,7 @@ fn impl_setters_for_vector(inner_name: &str) -> m4::TokenStream {
             self.0.push(v);
             self
         }
-        pub fn extend<T: ::std::iter::IntoIterator<Item=#inner>>(mut self, iter: T) -> Self {
+        pub fn extend<T: ::core::iter::IntoIterator<Item=#inner>>(mut self, iter: T) -> Self {
             for elem in iter {
                 self.0.push(elem);
             }

--- a/tools/codegen/src/generator/languages/rust/display.rs
+++ b/tools/codegen/src/generator/languages/rust/display.rs
@@ -32,8 +32,8 @@ impl ImplDisplay for ast::Array {
     fn impl_display(&self) -> m4::TokenStream {
         if self.typ.is_atom() {
             quote!(
-                use molecule::faster_hex::hex_string;
-                let raw_data = hex_string(&self.raw_data()).unwrap();
+                use molecule::hex_string;
+                let raw_data = hex_string(&self.raw_data());
                 write!(f, "{}(0x{})", Self::NAME, raw_data)
             )
         } else {
@@ -77,8 +77,8 @@ impl ImplDisplay for ast::FixVec {
     fn impl_display(&self) -> m4::TokenStream {
         if self.typ.is_atom() {
             quote!(
-                use molecule::faster_hex::hex_string;
-                let raw_data = hex_string(&self.raw_data()).unwrap();
+                use molecule::hex_string;
+                let raw_data = hex_string(&self.raw_data());
                 write!(f, "{}(0x{})", Self::NAME, raw_data)
             )
         } else {

--- a/tools/codegen/src/generator/languages/rust/entity/implementation.rs
+++ b/tools/codegen/src/generator/languages/rust/entity/implementation.rs
@@ -33,7 +33,7 @@ pub(in super::super) trait ImplEntity: HasName {
                     #reader::from_compatible_slice(slice).map(|reader| reader.to_entity())
                 }
                 fn new_builder() -> Self::Builder {
-                    ::std::default::Default::default()
+                    ::core::default::Default::default()
                 }
                 #internal
             }

--- a/tools/codegen/src/generator/languages/rust/entity/mod.rs
+++ b/tools/codegen/src/generator/languages/rust/entity/mod.rs
@@ -36,29 +36,29 @@ where
             #[derive(Clone)]
             pub struct #entity(molecule::bytes::Bytes);
 
-            impl ::std::fmt::LowerHex for #entity {
-                fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-                    use molecule::faster_hex::hex_string;
+            impl ::core::fmt::LowerHex for #entity {
+                fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                    use molecule::hex_string;
                     if f.alternate() {
                         write!(f, "0x")?;
                     }
-                    write!(f, "{}", hex_string(self.as_slice()).unwrap())
+                    write!(f, "{}", hex_string(self.as_slice()))
                 }
             }
 
-            impl ::std::fmt::Debug for #entity {
-                fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+            impl ::core::fmt::Debug for #entity {
+                fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                     write!(f, "{}({:#x})", Self::NAME, self)
                 }
             }
 
-            impl ::std::fmt::Display for #entity {
-                fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+            impl ::core::fmt::Display for #entity {
+                fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                     #display_stmts
                 }
             }
 
-            impl ::std::default::Default for #entity {
+            impl ::core::default::Default for #entity {
                 fn default() -> Self {
                     let v: Vec<u8> = vec![#( #default_content, )*];
                     #entity::new_unchecked(v.into())

--- a/tools/codegen/src/generator/languages/rust/enumerator.rs
+++ b/tools/codegen/src/generator/languages/rust/enumerator.rs
@@ -74,7 +74,7 @@ impl GenEnumerator for ast::Union {
         let entity_default = {
             let inner = &self.inner[0];
             let item_name = union_item_name(inner.typ.name());
-            quote!(#item_name(::std::default::Default::default()))
+            quote!(#item_name(::core::default::Default::default()))
         };
         let code_union_definitions_and_impl_traits = quote!(
             #[derive(Debug, Clone)]
@@ -86,14 +86,14 @@ impl GenEnumerator for ast::Union {
                 #( #union_items(#reader_inners<'r>), )*
             }
 
-            impl ::std::default::Default for #entity_union {
+            impl ::core::default::Default for #entity_union {
                 fn default() -> Self {
                     #entity_union::#entity_default
                 }
             }
 
-            impl ::std::fmt::Display for #entity_union {
-                fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+            impl ::core::fmt::Display for #entity_union {
+                fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                     match self {
                         #(
                             #entity_union_item_paths(ref item) => {
@@ -103,8 +103,8 @@ impl GenEnumerator for ast::Union {
                     }
                 }
             }
-            impl<'r> ::std::fmt::Display for #reader_union<'r> {
-                fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+            impl<'r> ::core::fmt::Display for #reader_union<'r> {
+                fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                     match self {
                         #(
                             #reader_union_item_paths(ref item) => {
@@ -116,14 +116,14 @@ impl GenEnumerator for ast::Union {
             }
 
             impl #entity_union {
-                pub(crate) fn display_inner(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                pub(crate) fn display_inner(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                     match self {
                         #( #entity_union_item_paths(ref item) => write!(f, "{}", item), )*
                     }
                 }
             }
             impl<'r> #reader_union<'r> {
-                pub(crate) fn display_inner(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                pub(crate) fn display_inner(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                     match self {
                         #( #reader_union_item_paths(ref item) => write!(f, "{}", item), )*
                     }
@@ -135,7 +135,7 @@ impl GenEnumerator for ast::Union {
             .zip(entity_inners.iter())
             .map(|(item_name, entity_name)| {
                 quote!(
-                    impl ::std::convert::From<#entity_name> for #entity_union {
+                    impl ::core::convert::From<#entity_name> for #entity_union {
                         fn from(item: #entity_name) -> Self {
                             #entity_union::#item_name(item)
                         }
@@ -148,7 +148,7 @@ impl GenEnumerator for ast::Union {
             .zip(reader_inners.iter())
             .map(|(item_name, reader_name)| {
                 quote!(
-                    impl<'r> ::std::convert::From<#reader_name<'r>> for #reader_union<'r> {
+                    impl<'r> ::core::convert::From<#reader_name<'r>> for #reader_union<'r> {
                         fn from(item: #reader_name<'r>) -> Self {
                             #reader_union::#item_name(item)
                         }

--- a/tools/codegen/src/generator/languages/rust/iterator.rs
+++ b/tools/codegen/src/generator/languages/rust/iterator.rs
@@ -29,7 +29,7 @@ fn gen_iterator_for_vector(self_name: &str, inner_name: &str, is_atom: bool) -> 
     let reader_inner = reader_name(inner_name);
     let common_part = quote!(
         pub struct #entity_iterator (#entity, usize, usize);
-        impl ::std::iter::Iterator for #entity_iterator {
+        impl ::core::iter::Iterator for #entity_iterator {
             type Item = #entity_inner;
             fn next(&mut self) -> Option<Self::Item> {
                 if self.1 >= self.2 {
@@ -41,12 +41,12 @@ fn gen_iterator_for_vector(self_name: &str, inner_name: &str, is_atom: bool) -> 
                 }
             }
         }
-        impl ::std::iter::ExactSizeIterator for #entity_iterator {
+        impl ::core::iter::ExactSizeIterator for #entity_iterator {
             fn len(&self) -> usize {
                 self.2 - self.1
             }
         }
-        impl ::std::iter::IntoIterator for #entity {
+        impl ::core::iter::IntoIterator for #entity {
             type Item = #entity_inner;
             type IntoIter = #entity_iterator;
             fn into_iter(self) -> Self::IntoIter {
@@ -67,7 +67,7 @@ fn gen_iterator_for_vector(self_name: &str, inner_name: &str, is_atom: bool) -> 
                 }
             }
             pub struct #reader_iterator<'t, 'r> (&'t #reader<'r>, usize, usize);
-            impl<'t: 'r, 'r> ::std::iter::Iterator for #reader_iterator<'t, 'r> {
+            impl<'t: 'r, 'r> ::core::iter::Iterator for #reader_iterator<'t, 'r> {
                 type Item = #reader_inner<'t>;
                 fn next(&mut self) -> Option<Self::Item> {
                     if self.1 >= self.2 {
@@ -79,7 +79,7 @@ fn gen_iterator_for_vector(self_name: &str, inner_name: &str, is_atom: bool) -> 
                     }
                 }
             }
-            impl<'t: 'r, 'r> ::std::iter::ExactSizeIterator for #reader_iterator<'t, 'r> {
+            impl<'t: 'r, 'r> ::core::iter::ExactSizeIterator for #reader_iterator<'t, 'r> {
                 fn len(&self) -> usize {
                     self.2 - self.1
                 }

--- a/tools/codegen/src/generator/languages/rust/reader/mod.rs
+++ b/tools/codegen/src/generator/languages/rust/reader/mod.rs
@@ -30,24 +30,24 @@ where
             #[derive(Clone, Copy)]
             pub struct #reader<'r>(&'r [u8]);
 
-            impl<'r> ::std::fmt::LowerHex for #reader<'r> {
-                fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-                    use molecule::faster_hex::hex_string;
+            impl<'r> ::core::fmt::LowerHex for #reader<'r> {
+                fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                    use molecule::hex_string;
                     if f.alternate() {
                         write!(f, "0x")?;
                     }
-                    write!(f, "{}", hex_string(self.as_slice()).unwrap())
+                    write!(f, "{}", hex_string(self.as_slice()))
                 }
             }
 
-            impl<'r> ::std::fmt::Debug for #reader<'r> {
-                fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+            impl<'r> ::core::fmt::Debug for #reader<'r> {
+                fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                     write!(f, "{}({:#x})", Self::NAME, self)
                 }
             }
 
-            impl<'r> ::std::fmt::Display for #reader<'r> {
-                fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+            impl<'r> ::core::fmt::Display for #reader<'r> {
+                fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                     #display_stmts
                 }
             }

--- a/tools/compiler/Cargo.lock
+++ b/tools/compiler/Cargo.lock
@@ -52,17 +52,13 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "bytes"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "case"
 version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -94,25 +90,11 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "faster-hex"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "generic-array"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "iovec"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -129,8 +111,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "molecule"
 version = "0.4.0"
 dependencies = [
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "faster-hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -318,11 +299,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "winapi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -361,14 +337,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum block-padding 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6d4dc3af3ee2e12f3e5d224e5e1e3d73668abbeb69e566d361f7d5563a4fdf09"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
-"checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 "checksum case 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fd6c0e7b807d60291f42f33f58480c0bfafe28ed08286446f45e463728cf9c1c"
+"checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
-"checksum faster-hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ec0ddfd1edbd5feb84f73d3068f7e5edba48b438caee3fb8e9ccb3e58cc70c5a"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
-"checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
 "checksum maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
@@ -393,7 +367,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
-"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9"


### PR DESCRIPTION
### Brief

At first, I try to do just few changes on #12, but after a lot of tests, I think there are lots of things could be remove or update in that PR, so I use the master branch as my base branch and implement it in another way.

### Details

The reasons why I didn't just approve that PR or just updated from that PR:

- The test for `no-std` in that PR (`examples/nostd-tests`) didn't work correctly.

  Reason:
  - `std` is the default feature for `molecule`.
  - `codegen` is dependent on `molecule`.
  - `build.rs` for `examples/nostd-tests` is dependent on `molecule`.
  - Since rust had compiled the moleculewith `feature = "std"`, it will use the molecule with `feature = "std"`, even though we had written the `default-features = false` in `Cargo.toml`.
  - So, at last, `examples/nostd-tests` is dependent on `molecule`with `feature = "std"`, not `no-std`.
  - [A simple example is HERE (CLICK TO DOWNLOAD).](https://github.com/nervosnetwork/molecule/files/3995975/example.zip)

- The code for test can be reusable, coping more than 350 lines is unnecessary (could be controlled by features).

- Since `Builder::write()` for `no-std` couldn't throw errors, that PR remove the return `Result` from function signature, so we can't handle the errors for some scenes with `std`.

  I just keep the function signature as previous, and I use `Result<(), std::io::Error>` for `std` and `Result<(), NeverType>` for `no-std` ([`NeverType` haven't released in lastest `Rust`, so I use `core::convert::Infallible` temporarily](https://doc.rust-lang.org/core/convert/enum.Infallible.html#future-compatibility)).

- Threads is not supported in `no-std`, so we don't have to use `bytes`.
  (`bytes::Bytes::slice(..)` is significantly slower than `&slice[..]` or `&vector[..]`, I have ran benchmark for getters 3 month ago.)

  I use a new type of `Vec<u8>` for `no-std`.

  It will cost more memory if we use `Entity` to access fields or items (since it will clone a part of memory), but we can just use the `Reader`to instead of.
  The `Reader` is significantly more effective no matter the `Entity` is base on `Vec<u8>` or `bytes::Bytes`.

  And we can remove almost all dependencies to reduce the size of the binary.
  For the `ci-tests/src/main.rs`: `411K -> 371K: 10%` (`release`, `debug=false`, `lto=true`, `codegen-units=1`, `strip`).

- We don't have to upgrade `bytes`. (We can do it later. )

  **TODO**: We can use a feature to support `thread-safe Entity` for `no-std`(**someday**).

- I disagree to introduce `failure` because of the same reason as above (unnecessary dependency and smaller binary for `no-std`).

  And `failure` is not the recommend for rust community any more, see [`thiserror`] and [`anyhow`] for more details.

[`thiserror`]: https://crates.io/crates/thiserror
[`anyhow`]: https://crates.io/crates/anyhow

- We don't have to handle error for the function `hex_string`, it could not be failed.

### Tips for Review

- [`#![no_std]` doesn't mean it will NOT use the `std` crate or it will compile this crate in `no-std` mode. It just prevents rust from loading the standard library automatically, **for current crate only**.](https://docs.rust-embedded.org/embedonomicon/smallest-no-std.html#what-does-no_std-mean)