### PR TITLE
fix(codegen/c): name conflict for a kind of generated macros

### DIFF
--- a/examples/ci-tests/Makefile
+++ b/examples/ci-tests/Makefile
@@ -34,7 +34,7 @@ refresh-comipler:
 debug:
 	@cargo build
 
-test: test-rust test-rust-no-std test-c test-mixed
+test: test-rust test-rust-no-std test-c test-mixed test-import
 
 test-rust:
 	@cargo test --all
@@ -89,7 +89,7 @@ test-rust-import: tmpdir ${MOL_DEPS}
 	@echo '[dependencies]'                                              >> "${TMPDIR}/import/rust/Cargo.toml"
 	@echo 'molecule = { path = "../../../../../bindings/rust" }'        >> "${TMPDIR}/import/rust/Cargo.toml"
 	@cd "${TMPDIR}/import/rust"; cargo build
-	echo "Passed: Test Rust Import."
+	@echo "Passed: Test Rust Import."
 
 test-c-import: tmpdir ${MOL_DEPS}
 	@mkdir -p \
@@ -105,7 +105,7 @@ test-c-import: tmpdir ${MOL_DEPS}
 	@"${MOLC}" --language c --schema-file schemas/import/c/cc/cc.mol > "${TMPDIR}/import/c/c/cc/cc.h"
 	@"${MOLC}" --language c --schema-file schemas/import/b/test.mol  > "${TMPDIR}/import/c/b/test.c"
 	@${CC} ${CFLAGS} -I${MOLINC} -c "${TMPDIR}/import/c/b/test.c" -o "${TMPDIR}/import/c/b/test.o"
-	echo "Passed: Test C Import."
+	@echo "Passed: Test C Import."
 
 ${MOLC}:
 	@cd ../../tools/compiler; cargo build --release

--- a/tools/codegen/src/generator/languages/c/mod.rs
+++ b/tools/codegen/src/generator/languages/c/mod.rs
@@ -37,7 +37,7 @@ impl Generator {
         w!(o, "#endif /* __cplusplus */                               ");
         w!(o, "                                                       ");
         w!(o, "#ifndef {}                              ", api_decorator);
-        w!(o, "#define __DEFINE_MOLECULE_API_DECORATOR                ");
+        w!(o, "#define __DEFINE_MOLECULE_API_DECORATOR_{}          ", n);
         w!(o, "#define {}                              ", api_decorator);
         w!(o, "#endif /* {} */                         ", api_decorator);
         Ok(())
@@ -47,10 +47,10 @@ impl Generator {
         let n = name.to_snake().to_uppercase();
         let api_decorator = utilities::API_DECORATOR;
         w!(o, "                                                       ");
-        w!(o, "#ifdef __DEFINE_MOLECULE_API_DECORATOR                 ");
+        w!(o, "#ifdef __DEFINE_MOLECULE_API_DECORATOR_{}           ", n);
         w!(o, "#undef {}                               ", api_decorator);
-        w!(o, "#undef __DEFINE_MOLECULE_API_DECORATOR                 ");
-        w!(o, "#endif /* __DEFINE_MOLECULE_API_DECORATOR */           ");
+        w!(o, "#undef __DEFINE_MOLECULE_API_DECORATOR_{}           ", n);
+        w!(o, "#endif /* __DEFINE_MOLECULE_API_DECORATOR_{} */     ", n);
         w!(o, "                                                       ");
         w!(o, "#ifdef __cplusplus                                     ");
         w!(o, "_CPP_END                                               ");


### PR DESCRIPTION
There is a bug:
- The api decorator for C functions is introduced by #8.
  When we found there is no api decorator, we will set a default api decorator.
- If a decorator was defined as default at the beginning, then undef it at the end, since #9.
- **[BUG] But the macros which are used to test if the decorator is the default decorator have a same name  in different headers.**
  So, the default decorator will be undef too early.
- I already wrote some tests, but I forgot to enable them in CI.