### PR TITLE
Remove link to the JS generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Molecule's reference implementation is in Rust and C.
 Implementations in other languages are maintained by respective authors.
 
 - [Go](https://github.com/driftluo/moleculec-go)
-- [JavaScript](https://github.com/Keith-CY/molecule-javascript)
 
 ## Benchmark
 


### PR DESCRIPTION
The current JS implementation is not friendly for contract developers, which are our main audiences.