### PR TITLE
docs: add links for several editors plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Implementations in other languages are maintained by respective authors.
 - [Go](https://github.com/driftluo/moleculec-go)
 - [Modern JavaScript](https://github.com/xxuejie/moleculec-es)
 
+## Plugins for Editors
+
+- [Emacs](https://github.com/yangby-cryptape/emacs-molecule)
+- [Vim](https://github.com/yangby-cryptape/vim-molecule)
+- [Sublime Text](https://github.com/yangby-cryptape/sublimetext-molecule)
+
 ## Benchmark
 
 - [Benchmark in Rust with serde](https://github.com/nervosnetwork/serde_bench)


### PR DESCRIPTION
These editors plugins can make the schema files more readable (especially when you have a lot of comments in your schema files).