### PR TITLE
fix: fix comipile errors for c++

### DIFF
--- a/bindings/c/include/molecule_builder.h
+++ b/bindings/c/include/molecule_builder.h
@@ -2,9 +2,7 @@
 #define MOLECULE_BUILDER_H
 
 #ifdef __cplusplus
-#define _CPP_BEGIN extern "C" {
-#define _CPP_END }
-_CPP_BEGIN
+extern "C" {
 #endif /* __cplusplus */
 
 #include <stddef.h>
@@ -23,7 +21,7 @@ _CPP_BEGIN
  */
 
 // Test if the host is big endian machine.
-#define is_le()                 (*(unsigned char *)&(uint16_t){1})
+#define is_le()                 ((union { uint16_t i; unsigned char c; }){ .i = 1 }.c)
 
 /*
  * Definitions of types and simple utilities.
@@ -285,9 +283,7 @@ MOLECULE_API_DECORATOR mol_seg_res_t mol_dynvec_builder_finalize(mol_builder_t b
 #endif /* __DEFINE_MOLECULE_API_DECORATOR */
 
 #ifdef __cplusplus
-_CPP_END
-#undef _CPP_BEGIN
-#undef _CPP_END
+}
 #endif /* __cplusplus */
 
 #endif /* MOLECULE_BUILDER_H */

--- a/bindings/c/include/molecule_reader.h
+++ b/bindings/c/include/molecule_reader.h
@@ -2,9 +2,7 @@
 #define MOLECULE_READER_H
 
 #ifdef __cplusplus
-#define _CPP_BEGIN extern "C" {
-#define _CPP_END }
-_CPP_BEGIN
+extern "C" {
 #endif /* __cplusplus */
 
 #include <stdbool.h>
@@ -34,7 +32,7 @@ _CPP_BEGIN
  */
 
 // Test if the host is big endian machine.
-#define is_le()                 (*(unsigned char *)&(uint16_t){1})
+#define is_le()                 ((union { uint16_t i; unsigned char c; }){ .i = 1 }.c)
 
 /*
  * Definitions of types and simple utilities.
@@ -246,9 +244,7 @@ MOLECULE_API_DECORATOR mol_seg_t mol_fixvec_slice_raw_bytes(const mol_seg_t *inp
 #endif /* __DEFINE_MOLECULE_API_DECORATOR */
 
 #ifdef __cplusplus
-_CPP_END
-#undef _CPP_BEGIN
-#undef _CPP_END
+}
 #endif /* __cplusplus */
 
 #endif /* MOLECULE_READER_H */

--- a/examples/ci-tests/Makefile
+++ b/examples/ci-tests/Makefile
@@ -22,6 +22,7 @@ C_DEPS = ${MOL_DEPS} \
 		 ${MOLINC}/molecule_reader.h ${MOLINC}/molecule_builder.h
 
 CC = gcc
+CXX = g++
 CFLAGS = -Wall -Werror
 
 clean:
@@ -37,7 +38,7 @@ refresh-comipler:
 debug:
 	@cargo build
 
-test: test-rust test-rust-no-std test-c test-mixed test-import
+test: test-rust test-rust-no-std test-c test-cpp test-mixed test-import
 
 test-rust:
 	@cargo test --all
@@ -48,6 +49,9 @@ test-rust-no-std:
 test-c: tmpdir ${TMPDIR}/test-build-default ${BIN_GEN_C_TESTS} ${BINS_C_TESTS}
 	@${TMPDIR}/test-build-default
 	@for bin in ${BINS_C_TESTS} ; do "$${bin}"; done
+
+test-cpp: tmpdir ${TMPDIR}/test-build-default-cpp
+	@${TMPDIR}/test-build-default-cpp
 
 test-mixed: tmpdir ${TMPDIR}/simple-example
 	@tmpdir="${TMPDIR}" scripts/test-mixed simple-example
@@ -82,6 +86,9 @@ ${HEADER_GEN}: ${SCHEMA_FILE}
 
 ${TMPDIR}/test-build-default: c/test-build-default.c ${C_DEPS}
 	@${CC} ${CFLAGS} -I${MOLINC} -o $@ $<
+
+${TMPDIR}/test-build-default-cpp: c/test-build-default.c ${C_DEPS}
+	@${CXX} ${CFLAGS} -I${MOLINC} -o $@ $<
 
 ${TMPDIR}/simple-example: c/simple-example.c ${C_DEPS}
 	@${CC} ${CFLAGS} -I${MOLINC} -o $@ $<

--- a/examples/ci-tests/c/test-build-default.c
+++ b/examples/ci-tests/c/test-build-default.c
@@ -4,7 +4,7 @@
     {                                                                   \
         total_cnt += 1;                                                 \
         uint32_t size = sizeof(MolDefault_ ## Name);                    \
-        char *name = #Name;                                             \
+        char const *name = #Name;                                       \
         const uint8_t *expected = MolDefault_ ## Name;                  \
         mol_builder_t b;                                                \
         MolBuilder_ ## Name ## _init(&b);                               \
@@ -30,7 +30,7 @@
     }
 
 void test_build_default() {
-    test_start("Build Default");
+    test_start((char*)"Build Default");
 
     uint32_t failed_cnt = 0;
     uint32_t total_cnt = 0;

--- a/tools/codegen/src/generator/languages/c/mod.rs
+++ b/tools/codegen/src/generator/languages/c/mod.rs
@@ -31,9 +31,7 @@ impl Generator {
         w!(o, "#define {}_H                                        ", n);
         w!(o, "                                                       ");
         w!(o, "#ifdef __cplusplus                                     ");
-        w!(o, "#define _CPP_BEGIN extern \"C\" {{                     ");
-        w!(o, "#define _CPP_END }}                                    ");
-        w!(o, "_CPP_BEGIN                                             ");
+        w!(o, "extern \"C\" {{                                        ");
         w!(o, "#endif /* __cplusplus */                               ");
         w!(o, "                                                       ");
         w!(o, "#ifndef {}                              ", api_decorator);
@@ -53,9 +51,7 @@ impl Generator {
         w!(o, "#endif /* __DEFINE_MOLECULE_API_DECORATOR_{} */     ", n);
         w!(o, "                                                       ");
         w!(o, "#ifdef __cplusplus                                     ");
-        w!(o, "_CPP_END                                               ");
-        w!(o, "#undef _CPP_BEGIN                                      ");
-        w!(o, "#undef _CPP_END                                        ");
+        w!(o, "}}                                                     ");
         w!(o, "#endif /* __cplusplus */                               ");
         w!(o, "                                                       ");
         w!(o, "#endif /* {}_H */                                   ", n);


### PR DESCRIPTION
### Issues

- All `include` should be put before call those two macros to avoid nested.
- It's a warning for ISO C++, and I update the implementation to make g++ be happy.
  Still require the feature "C99 compound literals".