### PR TITLE
chore: upgrade faster-hex to v0.6.0

### DIFF
--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT"
 [dependencies]
 cfg-if = "1.0.0"
 bytes = { version = "1.0.0", optional = true }
-faster-hex = { version = "0.4.1", optional = true }
+faster-hex = { version = "^0.6", optional = true }
 
 [features]
 default = ["std"]

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -45,7 +45,7 @@ pub fn pack_number(num: Number) -> [u8; 4] {
 pub fn hex_string(input: &[u8]) -> String {
     cfg_if::cfg_if! {
         if #[cfg(feature = "std")] {
-            faster_hex::hex_string(input).unwrap()
+            faster_hex::hex_string(input)
         } else {
             use core::fmt::Write;
             let mut buf = String::new();


### PR DESCRIPTION
Fix compilation on Apple Silicon

change requirements to "^0.6"