### PR TITLE
fix: `Cargo.lock` for compiler is not up-to-date

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 ci: ci-example ci-crates
+	git diff --exit-code tools/compiler/Cargo.lock
 
 RUST_PROJS = examples/ci-tests bindings/rust tools/codegen tools/compiler
 C_PROJS = examples/ci-tests

--- a/tools/compiler/Cargo.lock
+++ b/tools/compiler/Cargo.lock
@@ -142,14 +142,14 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "molecule"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "molecule-codegen"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "case",
  "molecule",
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "moleculec"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "clap",
  "molecule-codegen",


### PR DESCRIPTION
When I tried to publish all crates, I found the `Cargo.lock` for compiler was not up-to-date.

So, this PR update that file and add a check in CI.