### PR TITLE
fix: remove a piece of unsafe code

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,47 +40,45 @@ jobs:
           components: clippy
       - name: Run
         run: make clippy
-  test-crates:
-    name: Tests / Build & Test
+  test-msrv:
+    name: Tests / Build (MSRV)
     needs: [ rustfmt, clippy ]
-    strategy:
-      matrix:
-        os: [ ubuntu-latest ]
-        rust:
-          - 1.52.1
-          - 1.41.0  # MSRV
-      fail-fast: true
-      max-parallel: 2
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Setup
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: ${{ matrix.rust }}
+          toolchain: 1.41.0 # MSRV
+          override: true
+      - name: Run
+        run: make ci-msrv
+  test-crates:
+    name: Tests / Build & Test
+    needs: [ rustfmt, clippy ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.52.1
           override: true
       - name: Run
         run: make ci-crates
   test-examples:
     name: Tests / Run Examples
     needs: [ rustfmt, clippy ]
-    strategy:
-      matrix:
-        os: [ ubuntu-latest ]
-        rust:
-          - 1.52.1
-          - 1.41.0  # MSRV
-      fail-fast: true
-      max-parallel: 2
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Setup
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: ${{ matrix.rust }}
+          toolchain: 1.52.1
           override: true
       - name: Run
         run: make ci-examples

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,9 @@ ci:
 	make ci-examples ci-crates; \
 	echo "Success!"
 
-RUST_PROJS = examples/ci-tests bindings/rust tools/codegen tools/compiler
+RUST_DEV_PROJS = examples/ci-tests
+RUST_PROD_PROJS = bindings/rust tools/codegen tools/compiler
+RUST_PROJS = ${RUST_DEV_PROJS} ${RUST_PROD_PROJS}
 C_PROJS = examples/ci-tests
 
 clean:
@@ -37,6 +39,16 @@ clippy:
 		cargo clippy --all --all-targets --all-features; \
 		cd - > /dev/null; \
 	done
+
+ci-msrv:
+	@set -eu; \
+	for dir in ${RUST_PROD_PROJS}; do \
+		cd "$${dir}"; \
+		cargo clean; \
+		cargo build --all --verbose; \
+		cd - > /dev/null; \
+	done; \
+	git diff --exit-code tools/compiler/Cargo.lock
 
 ci-crates:
 	@set -eu; \

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -3,7 +3,7 @@
 extern crate alloc;
 
 use alloc::string::String;
-use core::mem::{size_of, MaybeUninit};
+use core::mem::size_of;
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "std")] {
@@ -31,8 +31,7 @@ pub const NUMBER_SIZE: usize = size_of::<Number>();
 #[inline]
 pub fn unpack_number(slice: &[u8]) -> Number {
     // the size of slice should be checked before call this function
-    #[allow(clippy::uninit_assumed_init)]
-    let mut b: [u8; 4] = unsafe { MaybeUninit::uninit().assume_init() };
+    let mut b = [0u8; 4];
     b.copy_from_slice(&slice[..4]);
     Number::from_le_bytes(b)
 }


### PR DESCRIPTION
First, the code works fine with current stable rust toolchain.
But, rust toolchain doesn't guarantee that; so it could be broken in the future.

The latest docs said:
> Notice that the rules around uninitialized integers are not finalized yet, but until they are, it is advisable to avoid them.

And, there is no safe way to create an uninitialized array.

- At first, [`::std::mem::uninitialized()`] was the suggested method.

- One day, the compiler told us to replace that by [`MaybeUninit::uninit().assume_init()`].

  But after read the docs carefully, we found that it said that it is advisable to avoid them because it could cause immediate undefined behavior in someday (when the rules around uninitialized integers are finalized).

- Now, there is no suitable API for that, so just remove the unsafe code.

  [I find one API which looks well but still unstable.](https://doc.rust-lang.org/1.56.0/core/mem/union.MaybeUninit.html#method.write_slice)


[`::std::mem::uninitialized()`]: https://doc.rust-lang.org/1.30.0/core/mem/fn.uninitialized.html#examples
[`MaybeUninit::uninit().assume_init()`]: https://doc.rust-lang.org/1.41.0/core/mem/fn.uninitialized.html