### PR TITLE
feat: add replace api to vector

### DIFF
--- a/examples/ci-tests/src/simple-example.rs
+++ b/examples/ci-tests/src/simple-example.rs
@@ -18,11 +18,16 @@ fn display_test_data() {
         .f2(0x34u8.into())
         .f4(f2.clone())
         .build();
-    let f41 = types::Bytes::new_builder()
-        .push(0x12.into())
-        .push(0x34.into())
-        .push(0x56.into())
-        .build();
+    let f41 = {
+        let mut f41_builder = types::Bytes::new_builder()
+            .push(0x12.into())
+            .push(0x12.into())
+            .push(0x13.into());
+        assert_eq!(f41_builder.replace(1, 0x34.into()), Some(0x12.into()));
+        assert_eq!(f41_builder.replace(2, 0x56.into()), Some(0x13.into()));
+        assert_eq!(f41_builder.replace(3, 0x56.into()), None);
+        f41_builder.build()
+    };
     let f43 = types::Byte3Vec::new_builder()
         .push(f2.clone())
         .push(f2.clone())

--- a/tools/codegen/src/generator/languages/rust/builder/setters.rs
+++ b/tools/codegen/src/generator/languages/rust/builder/setters.rs
@@ -124,5 +124,8 @@ fn impl_setters_for_vector(inner_name: &str) -> m4::TokenStream {
             }
             self
         }
+        pub fn replace(&mut self, index: usize, v: #inner) -> Option<#inner> {
+            self.0.get_mut(index).map(|item| ::core::mem::replace(item, v))
+        }
     )
 }


### PR DESCRIPTION
case ref: https://github.com/nervosnetwork/axon/pull/68/files#diff-23e04433a8d944b64dc095f9c6ab49b7ebb452fb25fe461c0f31c7e02839f7eaR218-R229

The user needs to `replace` a value in the vector, and currently, the only way to do so is to iterate through the collection. With the `replace` interface, this large piece of code can be replaced