### PR TITLE
chore: bump version to v0.7.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.52.1
+          toolchain: 1.58.1
           override: true
           components: rustfmt
       - name: Run
@@ -35,7 +35,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.52.1
+          toolchain: 1.58.1
           override: true
           components: clippy
       - name: Run
@@ -64,7 +64,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.52.1
+          toolchain: 1.58.1
           override: true
       - name: Run
         run: make ci-crates
@@ -78,7 +78,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.52.1
+          toolchain: 1.58.1
           override: true
       - name: Run
         run: make ci-examples

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "molecule"
-version = "0.7.2"
+version = "0.7.3"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 description = "Rust bindings for molecule."

--- a/examples/ci-tests/Cargo.toml
+++ b/examples/ci-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "molecule-ci-tests"
-version = "0.7.2"
+version = "0.7.3"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 

--- a/examples/tests-loader/Cargo.toml
+++ b/examples/tests-loader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "molecule-tests-loader"
-version = "0.7.2"
+version = "0.7.3"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 

--- a/examples/tests-utils-c/Cargo.toml
+++ b/examples/tests-utils-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "molecule-tests-utils-c"
-version = "0.7.2"
+version = "0.7.3"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 

--- a/examples/tests-utils-rust/Cargo.toml
+++ b/examples/tests-utils-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "molecule-tests-utils-rust"
-version = "0.7.2"
+version = "0.7.3"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 

--- a/tools/codegen/Cargo.toml
+++ b/tools/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "molecule-codegen"
-version = "0.7.2"
+version = "0.7.3"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 description = "Code generator for molecule."
@@ -16,7 +16,7 @@ categories = [
 license = "MIT"
 
 [dependencies]
-molecule = { version = "=0.7.2", path = "../../bindings/rust", default-features = false }
+molecule = { version = "=0.7.3", path = "../../bindings/rust", default-features = false }
 property = "0.3.3"
 pest = "2.1.3"
 pest_derive = "2.1.0"

--- a/tools/codegen/src/generator/languages/c/mod.rs
+++ b/tools/codegen/src/generator/languages/c/mod.rs
@@ -80,7 +80,7 @@ impl super::LanguageGenerator for Generator {
         writeln!(writer, r#"#include "molecule_reader.h""#)?;
         writeln!(writer, r#"#include "molecule_builder.h""#)?;
         writeln!(writer)?;
-        Self::ifndef(writer, &ast.namespace())?;
+        Self::ifndef(writer, ast.namespace())?;
         let imports = ast.imports();
         if !imports.is_empty() {
             writeln!(writer)?;
@@ -117,7 +117,7 @@ impl super::LanguageGenerator for Generator {
         for decl in ast.major_decls() {
             decl.gen_builder_functions(writer)?;
         }
-        Self::endif(writer, &ast.namespace())?;
+        Self::endif(writer, ast.namespace())?;
         Ok(())
     }
 }

--- a/tools/codegen/src/generator/languages/rust/builder/definition.rs
+++ b/tools/codegen/src/generator/languages/rust/builder/definition.rs
@@ -97,7 +97,7 @@ fn def_builder_for_struct_or_table(self_name: &str, inner: &[ast::FieldDecl]) ->
 
 fn def_builder_for_vector(self_name: &str, inner_name: &str) -> m4::TokenStream {
     let builder = builder_name(self_name);
-    let inner = entity_name(&inner_name);
+    let inner = entity_name(inner_name);
     quote!(
         #[derive(Debug, Default)]
         pub struct #builder (pub(crate) Vec<#inner>);

--- a/tools/codegen/src/generator/languages/rust/builder/setters.rs
+++ b/tools/codegen/src/generator/languages/rust/builder/setters.rs
@@ -108,7 +108,7 @@ fn impl_setters_for_struct_or_table(inner: &[ast::FieldDecl]) -> m4::TokenStream
 }
 
 fn impl_setters_for_vector(inner_name: &str) -> m4::TokenStream {
-    let inner = entity_name(&inner_name);
+    let inner = entity_name(inner_name);
     quote!(
         pub fn set(mut self, v: Vec<#inner>) -> Self {
             self.0 = v;

--- a/tools/codegen/src/generator/languages/rust/import.rs
+++ b/tools/codegen/src/generator/languages/rust/import.rs
@@ -18,7 +18,7 @@ impl GenImport for ast::ImportStmt {
             let part = ident_new(part);
             stmt = quote!(#stmt #part::);
         }
-        let name = ident_new(&self.name());
+        let name = ident_new(self.name());
         quote!(#stmt #name::*;)
     }
 }

--- a/tools/compiler/Cargo.lock
+++ b/tools/compiler/Cargo.lock
@@ -142,14 +142,14 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "molecule"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "molecule-codegen"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "case",
  "molecule",
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "moleculec"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "clap",
  "molecule-codegen",

--- a/tools/compiler/Cargo.toml
+++ b/tools/compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moleculec"
-version = "0.7.2"
+version = "0.7.3"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 description = "Schema compiler for molecule."
@@ -30,7 +30,7 @@ path = "src/compiler-rust.rs"
 [dependencies]
 clap = { version = "2.33.3", features = ["yaml"] }
 which = "4.0.2"
-molecule-codegen = { version = "=0.7.2", path = "../codegen", features = ["compiler-plugin"] }
+molecule-codegen = { version = "=0.7.3", path = "../codegen", features = ["compiler-plugin"] }
 
 [badges]
 maintenance = { status = "experimental" }


### PR DESCRIPTION
- chore: upgrade the default rust toolchain for the ci environment
- chore: bump version to v0.7.3