### PR TITLE
perf: use const functions as default constructors (only for `std`)

### DIFF
--- a/bindings/rust/src/bytes.rs
+++ b/bindings/rust/src/bytes.rs
@@ -34,6 +34,10 @@ impl Deref for Bytes {
 }
 
 impl Bytes {
+    pub fn from_static(bytes: &[u8]) -> Self {
+        Self::from(bytes)
+    }
+
     pub fn slice(&self, range: impl RangeBounds<usize>) -> Self {
         let len = self.len();
         let begin = match range.start_bound() {

--- a/tools/codegen/src/generator/languages/rust/entity/mod.rs
+++ b/tools/codegen/src/generator/languages/rust/entity/mod.rs
@@ -23,6 +23,7 @@ where
     fn gen_entity(&self) -> m4::TokenStream {
         let entity = entity_name(self.name());
         let reader = reader_name(self.name());
+        let default_size = usize_lit(self.default_content().len());
         let default_content = self
             .default_content()
             .into_iter()
@@ -60,12 +61,13 @@ where
 
             impl ::core::default::Default for #entity {
                 fn default() -> Self {
-                    let v: Vec<u8> = vec![#( #default_content, )*];
-                    #entity::new_unchecked(v.into())
+                    let v = molecule::bytes::Bytes::from_static(&Self::DEFAULT_VALUE);
+                    #entity::new_unchecked(v)
                 }
             }
 
             impl #entity {
+                const DEFAULT_VALUE: [u8; #default_size] = [#( #default_content, )*];
                 #constants
                 #properties
                 #getters


### PR DESCRIPTION
`Bytes::from_static(..)` is a const function, we can use it in the default constructor for entities to improve the performance.

Ref: [`pub const fn from_static(bytes: &'static [u8]) -> Bytes`](https://docs.rs/bytes/1.1.0/bytes/struct.Bytes.html#method.from_static).