### PR TITLE
fix: remove useless code: an always false condition

### DIFF
--- a/tools/codegen/src/generator/languages/rust/reader/implementation.rs
+++ b/tools/codegen/src/generator/languages/rust/reader/implementation.rs
@@ -218,9 +218,6 @@ impl ImplReader for ast::Table {
                     if slice_len != total_size {
                         return ve!(Self, TotalSizeNotMatch, total_size, slice_len);
                     }
-                    if slice_len == molecule::NUMBER_SIZE && Self::FIELD_COUNT == 0 {
-                        return Ok(());
-                    }
                     if slice_len < molecule::NUMBER_SIZE * 2 {
                         return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE * 2, slice_len);
                     }


### PR DESCRIPTION
Close #60.

Since the removed code in the `else` branch of the following condition:

https://github.com/nervosnetwork/molecule/blob/5f94aa86d523d60e498ffefe01001fcf1ae70851/tools/codegen/src/generator/languages/rust/reader/implementation.rs#L180

then `Self::FIELD_COUNT` will be always greater than 0.

So this line of code could be removed.