### PR TITLE
Add syntax_version identifier to molecule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ ci:
 	@set -eu; \
 	export RUSTFLAGS='-D warnings'; \
 	make fmt clippy; \
-	make ci-examples ci-crates; \
+	make cargo-test ci-examples ci-crates; \
 	echo "Success!"
 
 RUST_DEV_PROJS = examples/ci-tests tests
@@ -39,6 +39,15 @@ clippy:
 		cargo clippy --all --all-targets --all-features; \
 		cd - > /dev/null; \
 	done
+
+cargo-test:
+	@set -eu; \
+	for dir in ${RUST_PROJS}; do \
+		cd "$${dir}"; \
+		cargo test; \
+		cd - > /dev/null; \
+	done
+
 
 ci-msrv:
 	@set -eu; \

--- a/tools/codegen/src/ast/mod.rs
+++ b/tools/codegen/src/ast/mod.rs
@@ -1,6 +1,8 @@
 pub(crate) mod raw;
 pub(crate) mod verified;
 
+pub use raw::SyntaxVersion;
+
 pub use verified::{
     Array, Ast, DefaultContent, DynVec, FieldDecl, FixVec, HasName, ImportStmt, ItemDecl, Option_,
     Primitive, Struct, Table, TopDecl, Union, UnionItemDecl,

--- a/tools/codegen/src/ast/raw/mod.rs
+++ b/tools/codegen/src/ast/raw/mod.rs
@@ -1,14 +1,35 @@
 use std::path::PathBuf;
 
+#[cfg(feature = "compiler-plugin")]
+use serde::{Deserialize, Serialize};
+
 use property::Property;
 
 mod utils;
 
 #[derive(Debug, Default, Property)]
 pub(crate) struct Ast {
+    syntax_version: Option<SyntaxVersion>,
     namespace: String,
     imports: Vec<ImportStmt>,
     decls: Vec<TopDecl>,
+}
+
+impl Default for SyntaxVersion {
+    fn default() -> Self {
+        Self { version: 1 }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Property)]
+#[property(get(public))]
+#[cfg_attr(
+    feature = "compiler-plugin",
+    derive(Deserialize, Serialize),
+    serde(deny_unknown_fields)
+)]
+pub struct SyntaxVersion {
+    version: usize,
 }
 
 #[derive(Debug, Clone, Property)]

--- a/tools/codegen/src/ast/verified/complete.rs
+++ b/tools/codegen/src/ast/verified/complete.rs
@@ -216,7 +216,11 @@ impl super::Ast {
             let result = decls_result.get(decl.name()).unwrap();
             decls.push(Rc::clone(result));
         }
+
+        let syntax_version = raw.syntax_version().unwrap().to_owned();
+
         Self {
+            syntax_version,
             namespace,
             imports,
             decls,

--- a/tools/codegen/src/ast/verified/mod.rs
+++ b/tools/codegen/src/ast/verified/mod.rs
@@ -12,11 +12,14 @@ mod recover;
 pub use default_content::DefaultContent;
 pub use has_name::HasName;
 
+use crate::ast::SyntaxVersion;
+
 type Deps<'a> = HashMap<&'a str, Rc<super::TopDecl>>;
 
 #[derive(Debug, Property)]
 #[property(get(public))]
 pub struct Ast {
+    syntax_version: SyntaxVersion,
     namespace: String,
     imports: Vec<ImportStmt>,
     decls: Vec<Rc<TopDecl>>,

--- a/tools/codegen/src/ast/verified/recover.rs
+++ b/tools/codegen/src/ast/verified/recover.rs
@@ -223,7 +223,10 @@ impl super::Ast {
             let result = decls_result.get(decl.name()).unwrap();
             decls.push(Rc::clone(result));
         }
+
+        let syntax_version = ir.syntax_version().to_owned();
         Self {
+            syntax_version,
             namespace,
             imports,
             decls,

--- a/tools/codegen/src/grammar.pest
+++ b/tools/codegen/src/grammar.pest
@@ -87,8 +87,12 @@ path_super      =   @{ "../" }
 path            =   { path_super* ~ (identifier ~ "/")* ~ identifier }
 import_stmt     =   { "import" ~ (brk)+ ~ path ~ (brk)* ~ stmt_end }
 
+syntax_version = @{ digit+ }
+syntax_version_stmt = { "syntax" ~ (brk)* ~ "=" ~ (brk)* ~ syntax_version ~ (brk)* ~ stmt_end}
+
 grammar         =   {
                         SOI ~ (brk)* ~
+                            (syntax_version_stmt)? ~ (brk)* ~
                             (import_stmt ~ (brk)*)* ~
                                 decl_stmt ~
                             ((brk)* ~ decl_stmt)* ~ (brk)* ~

--- a/tools/codegen/src/ir/from_ast.rs
+++ b/tools/codegen/src/ir/from_ast.rs
@@ -9,6 +9,7 @@ impl ToIntermediate for ast::Ast {
     type Ir = super::Ir;
     fn to_ir(&self) -> Self::Ir {
         Self::Ir {
+            syntax_version: self.syntax_version().to_owned(),
             namespace: self.namespace().to_owned(),
             imports: self.imports().iter().map(ToIntermediate::to_ir).collect(),
             decls: self.decls().iter().map(|decl| decl.to_ir()).collect(),

--- a/tools/codegen/src/ir/mod.rs
+++ b/tools/codegen/src/ir/mod.rs
@@ -14,6 +14,7 @@ use crate::ast::SyntaxVersion;
 #[derive(Debug, Property, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct Ir {
+    #[serde(default)]
     syntax_version: SyntaxVersion,
     namespace: String,
     imports: Vec<ImportStmt>,

--- a/tools/codegen/src/ir/mod.rs
+++ b/tools/codegen/src/ir/mod.rs
@@ -8,10 +8,13 @@ use property::Property;
 pub use format::Format;
 pub(crate) use from_ast::ToIntermediate;
 
+use crate::ast::SyntaxVersion;
+
 /// Intermediate file.
 #[derive(Debug, Property, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct Ir {
+    syntax_version: SyntaxVersion,
     namespace: String,
     imports: Vec<ImportStmt>,
     #[serde(rename = "declarations")]


### PR DESCRIPTION
This PR want to make molecule support syntax version identifier.

We can specify `syntax = {version}` now.

1. If syntax_version wasn't specified, it would be `1` by default.
2. All schema file you imported must have **same version** : a `syntax = 1` schema file can't import `syntax = 2` file, and `syntax = 2` file can't import `syntax = 1` schema file either.

--------

@yangby-cryptape @driftluo @code-monad @zhangsoledad Invite you to review this PR.