### PR TITLE
chore: bump version to v0.7.4

### DIFF
--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "molecule"
-version = "0.7.3"
+version = "0.7.4"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 description = "Rust bindings for molecule."

--- a/examples/ci-tests/Cargo.toml
+++ b/examples/ci-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "molecule-ci-tests"
-version = "0.7.3"
+version = "0.7.4"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 

--- a/examples/tests-loader/Cargo.toml
+++ b/examples/tests-loader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "molecule-tests-loader"
-version = "0.7.3"
+version = "0.7.4"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 

--- a/examples/tests-utils-c/Cargo.toml
+++ b/examples/tests-utils-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "molecule-tests-utils-c"
-version = "0.7.3"
+version = "0.7.4"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 

--- a/examples/tests-utils-rust/Cargo.toml
+++ b/examples/tests-utils-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "molecule-tests-utils-rust"
-version = "0.7.3"
+version = "0.7.4"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tests"
-version = "0.1.0"
+version = "0.7.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -10,9 +10,9 @@ edition = "2021"
 [dev-dependencies]
 codegen-0_7_3 = {package = "molecule-codegen", version = "0.7.3", features = ["compiler-plugin"]}
 codegen-dev = {package = "molecule-codegen", path = "../tools/codegen", features = ["compiler-plugin"]}
-molecule = "0.7.3"
+molecule = {package = "molecule", path = "../bindings/rust"}
 
 [build-dependencies]
 codegen-0_7_3 = {package = "molecule-codegen", version = "0.7.3", features = ["compiler-plugin"]}
 codegen-dev = {package = "molecule-codegen", path = "../tools/codegen", features = ["compiler-plugin"]}
-molecule = "0.7.3"
+molecule = {package = "molecule", path = "../bindings/rust"}

--- a/tools/codegen/Cargo.toml
+++ b/tools/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "molecule-codegen"
-version = "0.7.3"
+version = "0.7.4"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 description = "Code generator for molecule."
@@ -16,7 +16,7 @@ categories = [
 license = "MIT"
 
 [dependencies]
-molecule = { version = "=0.7.3", path = "../../bindings/rust", default-features = false }
+molecule = { version = "=0.7.4", path = "../../bindings/rust", default-features = false }
 property = "0.3.3"
 pest = "2.1.3"
 pest_derive = "2.1.0"

--- a/tools/compiler/Cargo.lock
+++ b/tools/compiler/Cargo.lock
@@ -183,14 +183,14 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "molecule"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "molecule-codegen"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "case",
  "molecule",
@@ -208,7 +208,7 @@ dependencies = [
 
 [[package]]
 name = "moleculec"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "clap",
  "molecule-codegen",

--- a/tools/compiler/Cargo.toml
+++ b/tools/compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moleculec"
-version = "0.7.3"
+version = "0.7.4"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 description = "Schema compiler for molecule."
@@ -30,7 +30,7 @@ path = "src/compiler-rust.rs"
 [dependencies]
 clap = { version = "3", features = ["yaml", "cargo"] }
 which = "4.0.2"
-molecule-codegen = { version = "=0.7.3", path = "../codegen", features = ["compiler-plugin"] }
+molecule-codegen = { version = "=0.7.4", path = "../codegen", features = ["compiler-plugin"] }
 
 [badges]
 maintenance = { status = "experimental" }


### PR DESCRIPTION
We have merged "custom Union ID" feature (#65 ) into master, then this PR want to bump version from `0.7.3` to `v0.7.4`. @yangby-cryptape @quake 