### PR TITLE
add test case for custom Union ID feature

### DIFF
--- a/examples/ci-tests/src/lib.rs
+++ b/examples/ci-tests/src/lib.rs
@@ -126,6 +126,7 @@ macro_rules! testset {
     (union, $callback:ident) => {
         use $crate::types::*;
         $callback!(UnionA);
+        $callback!(UnionB);
     };
     (all, $callback:ident) => {
         use $crate::types::*;

--- a/examples/tests-loader/src/generators/c.rs
+++ b/examples/tests-loader/src/generators/c.rs
@@ -134,9 +134,8 @@ impl GenTest for types::Union {
                 union
                     .items()
                     .iter()
-                    .enumerate()
-                    .find(|(_, inner_item)| inner_item.typ().name() == item.typ())
-                    .map(|(index, _)| index)
+                    .find(|inner_item| inner_item.typ().name() == item.typ())
+                    .map(|item| item.id())
                     .unwrap()
             } else {
                 panic!("Error: type for {} is incorrect", self.name());

--- a/test/schemas/types.mol
+++ b/test/schemas/types.mol
@@ -177,6 +177,11 @@ union UnionA {
     Table6Opt,
 }
 
+union UnionB {
+    byte : 2,
+    Word : 4,
+}
+
 table TableA {
     f1: Word2,
     f2: StructA,

--- a/test/vectors/default.yaml
+++ b/test/vectors/default.yaml
@@ -264,3 +264,6 @@
 -
   name: UnionA
   expected: "0x00000000//00"
+-
+  name: UnionB
+  expected: "0x02000000//00"

--- a/test/vectors/simple.yaml
+++ b/test/vectors/simple.yaml
@@ -527,3 +527,15 @@
                00000000_0000\
                00000000\
                04000000"
+-
+  name: UnionB
+  item:
+    type: byte
+    data: "0x02"
+  expected: "0x02000000//02"
+-
+  name: UnionB
+  item:
+    type: Word
+    data: "0x0001"
+  expected: "0x04000000//0001"


### PR DESCRIPTION
This PR:
- fix codegen for `C`'s default union value should be first union item.
- add test case for custom Union ID feature.

Request for review: @driftluo @yangby-cryptape @code-monad