### PR TITLE
Fix: C code generator should provide `const uint8_t *` as 4th argument to  `mol_union_builder_initialize`

### DIFF
--- a/test/schemas/types.mol
+++ b/test/schemas/types.mol
@@ -182,6 +182,16 @@ union UnionB {
     Word : 4,
 }
 
+union UnionC {
+    Word,
+    byte,
+}
+
+union UnionD {
+    Word : 2,
+    byte : 4,
+}
+
 table TableA {
     f1: Word2,
     f2: StructA,

--- a/test/vectors/default.yaml
+++ b/test/vectors/default.yaml
@@ -267,3 +267,9 @@
 -
   name: UnionB
   expected: "0x02000000//00"
+-
+  name: UnionC
+  expected: "0x00000000//0000"
+-
+  name: UnionD
+  expected: "0x02000000//0000"

--- a/test/vectors/simple.yaml
+++ b/test/vectors/simple.yaml
@@ -539,3 +539,27 @@
     type: Word
     data: "0x0001"
   expected: "0x04000000//0001"
+-
+  name: UnionC
+  item:
+    type: Word
+    data: "0x0001"
+  expected: "0x00000000//0001"
+-
+  name: UnionC
+  item:
+    type: byte
+    data: "0x02"
+  expected: "0x01000000//02"
+-
+  name: UnionD
+  item:
+    type: Word
+    data: "0x0002"
+  expected: "0x02000000//0002"
+-
+  name: UnionD
+  item:
+    type: byte
+    data: "0x04"
+  expected: "0x04000000//04"

--- a/tools/codegen/src/generator/languages/c/builder.rs
+++ b/tools/codegen/src/generator/languages/c/builder.rs
@@ -110,8 +110,7 @@ impl GenBuilder for ast::Union {
             let name = if default.is_byte() {
                 "NULL".to_owned()
             } else {
-                let name = default.default_constant();
-                format!("&{}", name)
+                default.default_constant()
             };
             let data_capacity = calculate_capacity(molecule::NUMBER_SIZE + len);
             let macro_content = format!(


### PR DESCRIPTION
This PR fix a bug in C code generator, and added some test case.