### PR TITLE
feat: more conversion

### DIFF
--- a/examples/ci-tests/tests/build.rs
+++ b/examples/ci-tests/tests/build.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::cognitive_complexity)]
 
+use std::{convert::TryFrom, iter::FromIterator};
+
 use molecule::prelude::*;
 
 use molecule_ci_tests::testset;
@@ -42,4 +44,20 @@ macro_rules! verify_build_empty {
 #[test]
 fn build_empty_can_verify() {
     testset!(all, verify_build_empty);
+}
+
+#[test]
+fn test_conversion() {
+    use molecule_ci_tests::types::*;
+
+    assert_eq!(
+        Byte11::try_from(&[3; 11][..]).unwrap().as_bytes(),
+        &[3; 11][..],
+    );
+    assert_eq!(
+        u32::from_le_bytes(Byte4::from(3u32.to_le_bytes()).into()),
+        3u32,
+    );
+    let _ = BytesVecOpt::from(BytesVec::from_iter([Bytes::from_iter([3, 4])]));
+    let _ = UnionA::from(Byte::from(3u8));
 }

--- a/tools/codegen/src/generator/languages/rust/generator.rs
+++ b/tools/codegen/src/generator/languages/rust/generator.rs
@@ -15,6 +15,7 @@ impl Generator for ast::Option_ {
         writeln!(writer, "{}", self.gen_entity())?;
         writeln!(writer, "{}", self.gen_reader())?;
         writeln!(writer, "{}", self.gen_builder())?;
+        writeln!(writer, "{}", self.gen_from())?;
         Ok(())
     }
 }
@@ -25,6 +26,7 @@ impl Generator for ast::Union {
         writeln!(writer, "{}", self.gen_reader())?;
         writeln!(writer, "{}", self.gen_builder())?;
         writeln!(writer, "{}", self.gen_enumerator())?;
+        writeln!(writer, "{}", self.gen_from())?;
         Ok(())
     }
 }
@@ -34,6 +36,7 @@ impl Generator for ast::Array {
         writeln!(writer, "{}", self.gen_entity())?;
         writeln!(writer, "{}", self.gen_reader())?;
         writeln!(writer, "{}", self.gen_builder())?;
+        writeln!(writer, "{}", self.gen_from())?;
         Ok(())
     }
 }
@@ -53,6 +56,7 @@ impl Generator for ast::FixVec {
         writeln!(writer, "{}", self.gen_reader())?;
         writeln!(writer, "{}", self.gen_builder())?;
         writeln!(writer, "{}", self.gen_iterator())?;
+        writeln!(writer, "{}", self.gen_from_iter())?;
         Ok(())
     }
 }
@@ -63,6 +67,7 @@ impl Generator for ast::DynVec {
         writeln!(writer, "{}", self.gen_reader())?;
         writeln!(writer, "{}", self.gen_builder())?;
         writeln!(writer, "{}", self.gen_iterator())?;
+        writeln!(writer, "{}", self.gen_from_iter())?;
         Ok(())
     }
 }


### PR DESCRIPTION
Implement more conversion traits to make entities easier to build/use (close #63):

* FooOpt from Foo
* FooArray from/into [Foo; n]
* FooArray TryFrom &[Foo]
* Union entity from item
* Vec FromIterator item
* ByteArray from/into [u8; n]
* ByteArray TryFrom &[u8]
* ByteArrayReader Into &[u8; n]
* ByteVec FromIterator u8

So instead of e.g.

```rust
.foo_opt(FooOpt::new_builder().set(Some(foo)).build())
.foo_vec(FooVec::new_builder().extend(foo_iter).build())
.foo_union(FooUnion::new_builder().set(foo).build())
```

we can use:

```rust
.foo_opt(foo.into())
.foo_vec(foo_iter.collect())
.foo_union(foo.into())
```

It's also easier to work with e.g. `Uint32`: `3u32.to_le_bytes().into()`, `u32::from_le_bytes(x.into())`.