### PR TITLE
ci: upgrade ci deps and the rust-toolchain

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.58.1
+          toolchain: 1.75.0
           components: rustfmt
       - name: Run
         run: make fmt
@@ -32,7 +32,7 @@ jobs:
       - name: Setup
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.71.1
+          toolchain: 1.75.0
           components: clippy
       - name: Run
         run: make clippy
@@ -57,7 +57,7 @@ jobs:
       - name: Setup
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.58.1
+          toolchain: 1.75.0
       - name: Run
         run: make ci-crates
   test-examples:
@@ -69,7 +69,7 @@ jobs:
       - name: Setup
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.58.1
+          toolchain: 1.75.0
       - name: Run
         run: make ci-examples
   success:

--- a/tools/codegen/src/generator/languages/c/mod.rs
+++ b/tools/codegen/src/generator/languages/c/mod.rs
@@ -5,7 +5,7 @@ use case::CaseExt;
 use crate::{ast, C_API_VERSION_MIN, VERSION};
 
 #[macro_use]
-pub(self) mod utilities;
+mod utilities;
 
 mod import;
 

--- a/tools/codegen/src/generator/languages/rust/mod.rs
+++ b/tools/codegen/src/generator/languages/rust/mod.rs
@@ -4,29 +4,29 @@ use quote::quote;
 
 use crate::{ast, VERSION};
 
-pub(self) mod utilities;
+mod utilities;
 
-pub(self) mod builder;
-pub(self) mod entity;
-pub(self) mod reader;
+mod builder;
+mod entity;
+mod reader;
 
 /// Constants for `{ Entity, Reader }`
-pub(self) mod display;
+mod display;
 
 /// Constants for `{ Entity, Reader, Builder }`
-pub(self) mod constants;
+mod constants;
 
 /// Constants for `{ Entity, Reader }`
-pub(self) mod properties;
+mod properties;
 
 /// Constants for `{ Entity, Reader }`
-pub(self) mod getters;
+mod getters;
 
 /// Iterator for `{ Union } x { Entity, Reader }`
-pub(self) mod iterator;
+mod iterator;
 
 /// Enumerator for `{ Vector } x { Entity, Reader }`
-pub(self) mod enumerator;
+mod enumerator;
 
 mod import;
 use import::GenImport as _;

--- a/tools/codegen/src/parser/mod.rs
+++ b/tools/codegen/src/parser/mod.rs
@@ -246,7 +246,7 @@ union Foo {
         let ast0 = Parser::parse(&schema_file0.into_temp_path());
         let ast1 = Parser::parse(&schema_file1.into_temp_path());
 
-        for ast in vec![ast0, ast1] {
+        for ast in [ast0, ast1] {
             // get union items
             if let TopDecl::Union(union) = ast
                 .decls()


### PR DESCRIPTION
### Changes

- ci: upgrade ci deps

  Ref: actions-rs/toolchain#216

- chore: apply suggestions from latest toolchain and update ci script