### PR TITLE
feat: add bytes_vec features

### DIFF
--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -18,6 +18,8 @@ faster-hex = { version = "^0.6", optional = true }
 [features]
 default = ["std"]
 std = ["bytes/std", "faster-hex"]
+# Provide impls for bytes in no_std environment without depending on atomic
+bytes_vec = []
 
 [badges]
 maintenance = { status = "experimental" }

--- a/bindings/rust/src/bytes.rs
+++ b/bindings/rust/src/bytes.rs
@@ -1,0 +1,55 @@
+use alloc::{borrow::ToOwned, vec::Vec};
+use core::{
+    convert::From,
+    ops::{Bound, Deref, RangeBounds},
+};
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct Bytes(Vec<u8>);
+
+impl From<Vec<u8>> for Bytes {
+    fn from(value: Vec<u8>) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&[u8]> for Bytes {
+    fn from(value: &[u8]) -> Self {
+        Self(value.to_owned())
+    }
+}
+
+impl From<Bytes> for Vec<u8> {
+    fn from(value: Bytes) -> Self {
+        value.0
+    }
+}
+
+impl Deref for Bytes {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Bytes {
+    pub fn from_static(bytes: &[u8]) -> Self {
+        Self::from(bytes)
+    }
+
+    pub fn slice(&self, range: impl RangeBounds<usize>) -> Self {
+        let len = self.len();
+        let begin = match range.start_bound() {
+            Bound::Included(&n) => n,
+            Bound::Excluded(&n) => n + 1,
+            Bound::Unbounded => 0,
+        };
+        let end = match range.end_bound() {
+            Bound::Included(&n) => n + 1,
+            Bound::Excluded(&n) => n,
+            Bound::Unbounded => len,
+        };
+        Self::from(&self.0[begin..end])
+    }
+}

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -9,15 +9,19 @@ cfg_if::cfg_if! {
     if #[cfg(feature = "std")] {
         extern crate std;
 
+        pub use bytes;
         pub mod io {
             pub use std::io::{Error, Result, Write};
         }
     } else {
+        #[cfg(feature = "bytes_vec")]
+        pub mod bytes;
+        #[cfg(not(feature = "bytes_vec"))]
+        pub use bytes;
         pub mod io;
     }
 }
 
-pub use bytes;
 pub mod error;
 pub mod prelude;
 mod primitive;

--- a/tools/compiler/Cargo.lock
+++ b/tools/compiler/Cargo.lock
@@ -60,9 +60,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "case"


### PR DESCRIPTION
https://github.com/nervosnetwork/molecule/pull/75 introduced bytes crate in no_std env, which requires ckb2023 hardfork edition or [modification](https://github.com/xxuejie/ckb-contract-bytes-without-a) on old contract projects.

This PR add a `bytes_vec` feature, make it easier to upgrading older projects that want to continue using vec:

```diff
- molecule = { version = "0.7.5", default-features = false }
+ molecule = { version = "0.8.0", default-features = false, features = ["bytes_vec"] }
```