### PR TITLE
chore: bump version to v0.9.0

### DIFF
--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "molecule"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 description = "Rust bindings for molecule."

--- a/examples/ci-tests/Cargo.lock
+++ b/examples/ci-tests/Cargo.lock
@@ -209,7 +209,7 @@ checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "molecule"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "molecule-ci-tests"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "cc",
  "molecule",
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "molecule-codegen"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "case",
  "molecule",
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "molecule-tests-loader"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "faster-hex 0.4.1",
  "molecule-codegen",
@@ -258,7 +258,7 @@ dependencies = [
 
 [[package]]
 name = "molecule-tests-utils-rust"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "molecule-codegen",
  "molecule-tests-loader",

--- a/examples/ci-tests/Cargo.toml
+++ b/examples/ci-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "molecule-ci-tests"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 

--- a/examples/lazy-reader-tests/Cargo.lock
+++ b/examples/lazy-reader-tests/Cargo.lock
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "lazy-reader-tests"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "cc",
  "lazy_static",
@@ -113,7 +113,7 @@ checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "molecule"
-version = "0.7.5"
+version = "0.9.0"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "molecule-codegen"
-version = "0.7.5"
+version = "0.9.0"
 dependencies = [
  "case",
  "molecule",

--- a/examples/lazy-reader-tests/Cargo.toml
+++ b/examples/lazy-reader-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lazy-reader-tests"
-version = "0.1.0"
+version = "0.9.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/lazy-reader-tests/fuzz/Cargo.toml
+++ b/examples/lazy-reader-tests/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "types_rust-fuzz"
-version = "0.0.0"
+version = "0.9.0"
 publish = false
 edition = "2021"
 

--- a/examples/tests-loader/Cargo.toml
+++ b/examples/tests-loader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "molecule-tests-loader"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 

--- a/examples/tests-utils-c/Cargo.toml
+++ b/examples/tests-utils-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "molecule-tests-utils-c"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 

--- a/examples/tests-utils-rust/Cargo.toml
+++ b/examples/tests-utils-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "molecule-tests-utils-rust"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 

--- a/fuzzing/rust/Cargo.toml
+++ b/fuzzing/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "molecule-fuzzing"
-version = "0.1.0"
+version = "0.9.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/fuzzing/rust/fuzz/Cargo.toml
+++ b/fuzzing/rust/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "molecule-fuzzer"
-version = "0.1.0"
+version = "0.9.0"
 publish = false
 edition = "2021"
 

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -131,7 +131,7 @@ dependencies = [
 
 [[package]]
 name = "molecule"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -160,10 +160,10 @@ dependencies = [
 
 [[package]]
 name = "molecule-codegen"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "case",
- "molecule 0.8.0",
+ "molecule 0.9.0",
  "pest",
  "pest_derive",
  "proc-macro2",
@@ -367,11 +367,11 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
- "molecule 0.8.0",
+ "molecule 0.9.0",
  "molecule-codegen 0.7.3",
- "molecule-codegen 0.8.0",
+ "molecule-codegen 0.9.0",
 ]
 
 [[package]]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tests"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tools/codegen/Cargo.toml
+++ b/tools/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "molecule-codegen"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 description = "Code generator for molecule."
@@ -16,7 +16,7 @@ categories = [
 license = "MIT"
 
 [dependencies]
-molecule = { version = "=0.8.0", path = "../../bindings/rust", default-features = false }
+molecule = { version = "=0.9.0", path = "../../bindings/rust", default-features = false }
 property = "0.3.3"
 pest = "2.5.7"
 pest_derive = "2.5.7"

--- a/tools/compiler/Cargo.lock
+++ b/tools/compiler/Cargo.lock
@@ -168,7 +168,7 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "molecule"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "molecule-codegen"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "case",
  "molecule",
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "moleculec"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "clap",
  "molecule-codegen",

--- a/tools/compiler/Cargo.toml
+++ b/tools/compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moleculec"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 description = "Schema compiler for molecule."
@@ -34,7 +34,7 @@ path = "src/compiler-rust-lazy-reader.rs"
 [dependencies]
 clap = { version = "3", features = ["yaml", "cargo"] }
 which = "4.3.0"
-molecule-codegen = { version = "=0.8.0", path = "../codegen", features = ["compiler-plugin"] }
+molecule-codegen = { version = "=0.9.0", path = "../codegen", features = ["compiler-plugin"] }
 
 [badges]
 maintenance = { status = "experimental" }


### PR DESCRIPTION
### Description

Release a new version with a big feature, Rust lazy reader.

Release notes:

```markdown
### Important Updates

Features
- #77: Add Rust lazy reader (@XuJiandong)

[Full changes list](https://github.com/nervosnetwork/molecule/compare/v0.8.0...v0.9.0)
```

p.s. I have been asked to release a new version.