### PR TITLE
refactor: use core::Error without requiring std

### DIFF
--- a/bindings/rust/src/error.rs
+++ b/bindings/rust/src/error.rs
@@ -79,9 +79,5 @@ impl fmt::Display for Error {
     }
 }
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "std")] {
-        impl ::std::error::Error for VerificationError {}
-        impl ::std::error::Error for Error {}
-    }
-}
+impl core::error::Error for VerificationError {}
+impl core::error::Error for Error {}


### PR DESCRIPTION
This feature is introduced since Rust 1.81.
